### PR TITLE
feat: compile prompts from schema

### DIFF
--- a/colrvia5-main/assets/schemas/single-room-color-intake.json
+++ b/colrvia5-main/assets/schemas/single-room-color-intake.json
@@ -1,0 +1,528 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Single Room Color Intake",
+  "type": "object",
+  "properties": {
+    "roomType": {
+      "title": "Which room are we doing?",
+      "type": "string",
+      "enum": [
+        "kitchen",
+        "bathroom",
+        "bedroom",
+        "livingRoom",
+        "diningRoom",
+        "office",
+        "kidsRoom",
+        "laundryMudroom",
+        "entryHall",
+        "other"
+      ]
+    },
+    "usage": {
+      "title": "Who uses this room most, and what do you do here?",
+      "type": "string",
+      "description": "e.g., Family of four. We cook daily and hang at the island."
+    },
+    "moodWords": {
+      "title": "Pick up to three mood words",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "type": "string",
+        "enum": ["calm","cozy","happy","fresh","focused","moody","bright"]
+      }
+    },
+    "daytimeBrightness": {
+      "title": "How bright is it in the day?",
+      "type": "string",
+      "enum": ["veryBright","kindaBright","dim"]
+    },
+    "bulbColor": {
+      "title": "At night, what kind of bulbs?",
+      "type": "string",
+      "enum": ["cozyYellow_2700K","neutral_3000_3500K","brightWhite_4000KPlus"]
+    },
+    "boldDarkerSpot": {
+      "title": "Do you like a bold darker spot in this room?",
+      "type": "string",
+      "enum": ["loveIt","maybe","noThanks"]
+    },
+    "brandPreference": {
+      "title": "Pick one paint brand (or let us choose)",
+      "type": "string",
+      "enum": ["SherwinWilliams","BenjaminMoore","Behr","pickForMe"]
+    },
+    "existingElements": {
+      "type": "object",
+      "properties": {
+        "floorLook": {
+          "title": "Floors look mostly…",
+          "type": "string",
+          "enum": [
+            "yellowGoldWood",
+            "orangeWood",
+            "redBrownWood",
+            "brownNeutral",
+            "grayBrown",
+            "tileOrStone",
+            "other"
+          ]
+        },
+        "floorLookOtherNote": {
+          "title": "If other, tell us",
+          "type": "string"
+        },
+        "bigThingsToMatch": {
+          "title": "Big things to match (pick all that apply)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "countertops",
+              "backsplash",
+              "tile",
+              "bigFurniture",
+              "rug",
+              "curtains",
+              "builtIns",
+              "appliances",
+              "fireplace",
+              "none"
+            ]
+          }
+        },
+        "metals": {
+          "title": "If metal shows, what is it?",
+          "type": "string",
+          "enum": ["black","silver","goldWarm","mixed","none"]
+        },
+        "mustStaySame": {
+          "title": "Anything that must stay the same color?",
+          "type": "string",
+          "description": "e.g., trim stays white; cabinets stay navy"
+        }
+      }
+    },
+    "colorComfort": {
+      "type": "object",
+      "properties": {
+        "overallVibe": {
+          "title": "Overall vibe for color",
+          "type": "string",
+          "enum": [
+            "mostlySoftNeutrals",
+            "neutralsPlusGentleColors",
+            "confidentColorMoments"
+          ]
+        },
+        "warmCoolFeel": {
+          "title": "Warm vs cool feel",
+          "type": "string",
+          "enum": ["warmer","cooler","inBetween"]
+        },
+        "contrastLevel": {
+          "title": "Contrast level",
+          "type": "string",
+          "enum": ["verySoft","medium","crisp"]
+        },
+        "popColor": {
+          "title": "Would you enjoy one small “pop” color?",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        }
+      }
+    },
+    "finishes": {
+      "type": "object",
+      "properties": {
+        "wallsFinishPriority": {
+          "title": "Walls — what matters most?",
+          "type": "string",
+          "enum": ["easierToWipeClean","softerFlatterLook"]
+        },
+        "trimDoorsFinish": {
+          "title": "Trim/doors finish",
+          "type": "string",
+          "enum": ["aLittleShiny","softerShine"]
+        },
+        "specialNeeds": {
+          "title": "Any special needs?",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "kids",
+              "pets",
+              "steamyShowers",
+              "greaseHeavyCooking",
+              "rentalRules"
+            ]
+          }
+        }
+      }
+    },
+    "guardrails": {
+      "type": "object",
+      "properties": {
+        "mustHaves": {
+          "title": "Must-haves (please include…)",
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "hardNos": {
+          "title": "Hard NOs (please avoid…)",
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "photos": {
+      "title": "Add 2–3 daytime links and 1 nighttime (optional)",
+      "type": "array",
+      "items": {"type": "string", "format": "uri"}
+    }
+  },
+  "required": [
+    "roomType",
+    "usage",
+    "moodWords",
+    "daytimeBrightness",
+    "bulbColor",
+    "boldDarkerSpot",
+    "brandPreference"
+  ],
+  "$defs": {
+    "kitchen": {
+      "type": "object",
+      "properties": {
+        "cabinets": {
+          "title": "Kitchen cabinets",
+          "type": "string",
+          "enum": ["allNewColor","keepCurrentColor"]
+        },
+        "cabinetsCurrentColor": {
+          "title": "If keeping, what color are the cabinets now?",
+          "type": "string"
+        },
+        "island": {
+          "title": "Island",
+          "type": "string",
+          "enum": ["noIsland","hasIsland_okDarker","hasIsland_keepLight"]
+        },
+        "countertopsDescription": {
+          "title": "Countertops look like…",
+          "type": "string",
+          "description": "plain white, creamy, speckled, gray veins, warm stone"
+        },
+        "backsplash": {
+          "title": "Backsplash",
+          "type": "string",
+          "enum": ["white","cream","color","pattern","none","describe"]
+        },
+        "backsplashDescribe": {
+          "title": "Tell us more about the backsplash",
+          "type": "string"
+        },
+        "appliances": {
+          "title": "Appliances",
+          "type": "string",
+          "enum": ["stainless","black","white","mixed"]
+        },
+        "wallFeel": {
+          "title": "Walls should feel…",
+          "type": "string",
+          "enum": ["lightAiry","aBitCozier"]
+        },
+        "darkerSpots": {
+          "title": "Good spots for a darker moment",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["island","lowerCabinets","doors","none"]
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"cabinets": {"const": "keepCurrentColor"}}},
+          "then": {"required": ["cabinetsCurrentColor"]}
+        },
+        {
+          "if": {"properties": {"backsplash": {"const": "describe"}}},
+          "then": {"required": ["backsplashDescribe"]}
+        }
+      ]
+    },
+    "bathroom": {
+      "type": "object",
+      "properties": {
+        "tileMainColor": {
+          "title": "Tile main color",
+          "type": "string",
+          "enum": ["whiteOrCream","gray","color","pattern"]
+        },
+        "tileColorWhich": {
+          "title": "Which tile color?",
+          "type": "string"
+        },
+        "vanityTop": {
+          "title": "Vanity top",
+          "type": "string",
+          "enum": ["white","cream","wood","stone","other"]
+        },
+        "showerSteamLevel": {
+          "title": "Shower/steam level",
+          "type": "string",
+          "enum": ["low","medium","high"]
+        },
+        "fixtureMetal": {
+          "title": "Fixture metal",
+          "type": "string",
+          "enum": ["black","silver","gold","mixed"]
+        },
+        "goal": {
+          "title": "Goal",
+          "type": "string",
+          "enum": ["spaLike","energizing","moody"]
+        },
+        "darkerVanityOrDoor": {
+          "title": "Darker vanity or door?",
+          "type": "string",
+          "enum": ["vanity","door","neither"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"tileMainColor": {"const": "color"}}},
+          "then": {"required": ["tileColorWhich"]}
+        }
+      ]
+    },
+    "bedroom": {
+      "type": "object",
+      "properties": {
+        "sleepFeel": {
+          "title": "How should it feel when you sleep?",
+          "type": "string",
+          "enum": ["cocoon","airy","romantic","minimal"]
+        },
+        "beddingColors": {
+          "title": "Bedding colors",
+          "type": "string"
+        },
+        "headboard": {
+          "title": "Headboard",
+          "type": "string",
+          "enum": ["wood","upholstered","metal","none"]
+        },
+        "windowTreatments": {
+          "title": "Window treatments",
+          "type": "string",
+          "enum": ["white","woodTone","color","pattern","none"]
+        },
+        "darkerWallBehindBed": {
+          "title": "Darker wall behind bed?",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        }
+      }
+    },
+    "livingRoom": {
+      "type": "object",
+      "properties": {
+        "sofaColor": {"title": "Sofa color", "type": "string"},
+        "rugMainColors": {"title": "Rug main colors", "type": "string"},
+        "fireplace": {
+          "title": "Fireplace",
+          "type": "string",
+          "enum": ["brick","stone","painted","none"]
+        },
+        "fireplaceDetail": {"title": "Fireplace detail", "type": "string"},
+        "tvWall": {
+          "title": "TV wall",
+          "type": "string",
+          "enum": ["yes","no"]
+        },
+        "builtInsOrDoorColor": {
+          "title": "Built-ins or door color",
+          "type": "string"
+        }
+      }
+    },
+    "diningRoom": {
+      "type": "object",
+      "properties": {
+        "tableWoodTone": {"title": "Table wood tone", "type": "string"},
+        "chairs": {
+          "title": "Chairs",
+          "type": "string",
+          "enum": ["wood","upholstered","mixed"]
+        },
+        "lightFixtureMetal": {
+          "title": "Light fixture metal",
+          "type": "string",
+          "enum": ["black","silver","gold","mixed"]
+        },
+        "feeling": {
+          "title": "Feeling",
+          "type": "string",
+          "enum": ["cozy","formal","casual"]
+        },
+        "darkerBelowOrOneWall": {
+          "title": "Darker below or one wall?",
+          "type": "string",
+          "enum": ["darkerBelow","oneWall","no"]
+        }
+      }
+    },
+    "office": {
+      "type": "object",
+      "properties": {
+        "workMood": {
+          "title": "Work mood",
+          "type": "string",
+          "enum": ["focus","creative","relaxed"]
+        },
+        "screenGlare": {
+          "title": "Screen glare",
+          "type": "string",
+          "enum": ["yes","no"]
+        },
+        "deeperLibraryWallsOk": {
+          "title": "Deeper library walls ok?",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        },
+        "colorBookshelvesOrBuiltIns": {
+          "title": "Color bookshelves or built-ins",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        }
+      }
+    },
+    "kidsRoom": {
+      "type": "object",
+      "properties": {
+        "mood": {
+          "title": "Mood",
+          "type": "string",
+          "enum": ["playful","calm","bright"]
+        },
+        "mainFabricToyColors": {"title": "Main fabric/toy colors", "type": "string"},
+        "superWipeableWalls": {
+          "title": "Super wipeable walls?",
+          "type": "string",
+          "enum": ["yes","no"]
+        },
+        "smallColorPopOk": {
+          "title": "Small color pop ok?",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        }
+      }
+    },
+    "laundryMudroom": {
+      "type": "object",
+      "properties": {
+        "traffic": {
+          "title": "Traffic",
+          "type": "string",
+          "enum": ["low","medium","high"]
+        },
+        "cabinetsShelving": {
+          "title": "Cabinets/shelving",
+          "type": "string",
+          "enum": ["open","closed","mixed"]
+        },
+        "cabinetsColor": {
+          "title": "Cabinets color",
+          "type": "string",
+          "enum": ["white","wood","color"]
+        },
+        "hideDirtOrBrightClean": {
+          "title": "Hide dirt or bright clean?",
+          "type": "string",
+          "enum": ["hideDirt","brightClean"]
+        },
+        "doorColorMomentOk": {
+          "title": "Door color moment ok?",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        }
+      }
+    },
+    "entryHall": {
+      "type": "object",
+      "properties": {
+        "naturalLight": {
+          "title": "Natural light",
+          "type": "string",
+          "enum": ["lots","some","little"]
+        },
+        "stairsBanister": {
+          "title": "Stairs/banister",
+          "type": "string",
+          "enum": ["wood","painted","none"]
+        },
+        "woodTone": {
+          "title": "Wood tone",
+          "type": "string"
+        },
+        "paintColor": {
+          "title": "Paint color",
+          "type": "string"
+        },
+        "feel": {
+          "title": "Feel",
+          "type": "string",
+          "enum": ["welcoming","dramatic","simple"]
+        },
+        "doorColorMoment": {
+          "title": "Door color moment",
+          "type": "string",
+          "enum": ["yes","maybe","no"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"stairsBanister": {"const": "wood"}}},
+          "then": {"required": ["woodTone"]}
+        },
+        {
+          "if": {"properties": {"stairsBanister": {"const": "painted"}}},
+          "then": {"required": ["paintColor"]}
+        }
+      ]
+    },
+    "otherRoom": {
+      "type": "object",
+      "properties": {
+        "describeRoom": {
+          "title": "Describe the room",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "existingElements": {
+            "properties": {
+              "floorLook": {"const": "other"}
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "existingElements": {"required": ["floorLookOtherNote"]}
+        }
+      }
+    }
+  ]
+}
+

--- a/colrvia5-main/lib/services/interview_engine.dart
+++ b/colrvia5-main/lib/services/interview_engine.dart
@@ -45,6 +45,7 @@ class InterviewPrompt {
 
 class InterviewEngine extends ChangeNotifier {
   InterviewEngine._(this._allPrompts);
+  factory InterviewEngine.fromPrompts(List<InterviewPrompt> prompts) => InterviewEngine._(prompts);
   static InterviewEngine demo() => InterviewEngine._(_buildDemoPrompts());
 
   final List<InterviewPrompt> _allPrompts;

--- a/colrvia5-main/lib/services/schema_interview_compiler.dart
+++ b/colrvia5-main/lib/services/schema_interview_compiler.dart
@@ -1,0 +1,273 @@
+// lib/services/schema_interview_compiler.dart
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:color_canvas/services/interview_engine.dart';
+
+/// Compiles a (subset of) JSON Schema → List<InterviewPrompt>
+/// Supported: object/string/array/boolean, enum, min/maxItems, uniqueItems,
+/// nested properties, $defs (room branches), basic if/then required visibility.
+class SchemaInterviewCompiler {
+  final Map<String, dynamic> root;
+  SchemaInterviewCompiler(this.root);
+
+  static Future<SchemaInterviewCompiler> loadFromAsset(String path) async {
+    final raw = await rootBundle.loadString(path);
+    final json = jsonDecode(raw) as Map<String, dynamic>;
+    return SchemaInterviewCompiler(json);
+  }
+
+  List<InterviewPrompt> compile() {
+    final out = <InterviewPrompt>[];
+
+    // 1) Top-level properties
+    final props = (root['properties'] as Map?)?.cast<String, dynamic>() ?? {};
+    final requiredTop = (root['required'] as List?)?.cast<String>() ?? const [];
+    _compileObject('', props, requiredTop, out);
+
+    // 2) Room branches under $defs (kitchen/bathroom/...)
+    final defs = (root['$defs'] as Map?)?.cast<String, dynamic>() ?? {};
+    final roomDefs = [
+      'kitchen',
+      'bathroom',
+      'bedroom',
+      'livingRoom',
+      'diningRoom',
+      'office',
+      'kidsRoom',
+      'laundryMudroom',
+      'entryHall',
+      'otherRoom'
+    ];
+    for (final r in roomDefs) {
+      final def = (defs[r] as Map?)?.cast<String, dynamic>();
+      if (def == null) continue;
+      final rProps = (def['properties'] as Map?)?.cast<String, dynamic>() ?? {};
+      final rReq = (def['required'] as List?)?.cast<String>() ?? const [];
+      _compileObject('roomSpecific.', rProps, rReq, out);
+
+      // Visibility rules from def.allOf
+      final allOf = (def['allOf'] as List?)?.cast<dynamic>() ?? const [];
+      final visRules = _extractVisibilityRules(allOf, scopePrefix: 'roomSpecific.');
+      _applyVisibility(out, visRules);
+    }
+
+    // 3) Global conditional rules in root (e.g., floorLookOtherNote)
+    final allOfRoot = (root['allOf'] as List?)?.cast<dynamic>() ?? const [];
+    final rootVis = _extractVisibilityRules(allOfRoot);
+    _applyVisibility(out, rootVis);
+
+    return out;
+  }
+
+  void _compileObject(
+    String prefix,
+    Map<String, dynamic> props,
+    List<String> required,
+    List<InterviewPrompt> out,
+  ) {
+    for (final entry in props.entries) {
+      final key = entry.key;
+      final schema = (entry.value as Map).cast<String, dynamic>();
+      final id = prefix.isEmpty ? key : '$prefix$key';
+
+      final title = (schema['title'] as String?) ?? id;
+      final desc = schema['description'] as String?;
+      final type = schema['type'];
+
+      final isRequired = required.contains(key);
+
+      if (type == 'object') {
+        final childProps = (schema['properties'] as Map?)?.cast<String, dynamic>() ?? {};
+        final childReq = (schema['required'] as List?)?.cast<String>() ?? const [];
+        _compileObject('$id.', childProps, childReq, out);
+        continue;
+      }
+
+      if (type == 'string') {
+        final enums = (schema['enum'] as List?)?.cast<String>();
+        if (enums != null && enums.isNotEmpty) {
+          out.add(InterviewPrompt(
+            id: id,
+            title: title,
+            help: desc,
+            type: InterviewPromptType.singleSelect,
+            required: isRequired,
+            options: enums.map((e) => InterviewPromptOption(e, _labelize(e))).toList(),
+          ));
+        } else {
+          out.add(InterviewPrompt(
+            id: id,
+            title: title,
+            help: desc,
+            type: InterviewPromptType.freeText,
+            required: isRequired,
+          ));
+        }
+        continue;
+      }
+
+      if (type == 'boolean') {
+        out.add(InterviewPrompt(
+          id: id,
+          title: title,
+          help: desc,
+          type: InterviewPromptType.yesNo,
+          required: isRequired,
+          options: const [
+            InterviewPromptOption('yes', 'Yes'),
+            InterviewPromptOption('no', 'No'),
+          ],
+        ));
+        continue;
+      }
+
+      if (type == 'array') {
+        final items = (schema['items'] as Map?)?.cast<String, dynamic>() ?? {};
+        final itemType = items['type'];
+        final itemEnums = (items['enum'] as List?)?.cast<String>();
+        final minItems = schema['minItems'] as int?;
+        final maxItems = schema['maxItems'] as int?;
+
+        if (itemType == 'string' && itemEnums != null && itemEnums.isNotEmpty) {
+          out.add(InterviewPrompt(
+            id: id,
+            title: title,
+            help: desc,
+            type: InterviewPromptType.multiSelect,
+            isArray: true,
+            required: isRequired,
+            minItems: minItems,
+            maxItems: maxItems,
+            options: itemEnums.map((e) => InterviewPromptOption(e, _labelize(e))).toList(),
+          ));
+        } else {
+          // Free-form list captured into chips; UI can render a text field → "Add" to chips.
+          out.add(InterviewPrompt(
+            id: id,
+            title: title,
+            help: desc,
+            type: InterviewPromptType.multiSelect,
+            isArray: true,
+            required: isRequired,
+            minItems: minItems,
+            maxItems: maxItems,
+            options: const [],
+          ));
+        }
+        continue;
+      }
+    }
+  }
+
+  // --- Visibility extraction from allOf if/then blocks ---
+
+  /// Returns list of (targetId, dependsOnId, constValue)
+  List<_VisRule> _extractVisibilityRules(List<dynamic> allOf, {String scopePrefix = ''}) {
+    final rules = <_VisRule>[];
+    for (final raw in allOf) {
+      final block = (raw as Map?)?.cast<String, dynamic>() ?? const {};
+      if (block.isEmpty) continue;
+
+      final ifPart = (block['if'] as Map?)?.cast<String, dynamic>();
+      final thenPart = (block['then'] as Map?)?.cast<String, dynamic>();
+      if (ifPart == null || thenPart == null) continue;
+
+      final conditions = <String, dynamic>[];
+      _collectConstConditions(ifPart, '', conditions);
+      if (conditions.isEmpty) continue;
+
+      final requiredTargets = <String>[];
+      _collectRequiredTargets(thenPart, '', requiredTargets);
+
+      // Pair each condition with each required target
+      for (final c in conditions) {
+        final condPath = scopePrefix + (c['path'] as String);
+        final condVal = c['const'];
+        for (final t in requiredTargets) {
+          final targetId = scopePrefix + t;
+          rules.add(_VisRule(targetId: targetId, dependsOn: condPath, equalsValue: condVal));
+        }
+      }
+    }
+    return rules;
+  }
+
+  void _collectConstConditions(Map<String, dynamic> node, String prefix, List<Map<String, dynamic>> out) {
+    if (node.containsKey('const')) {
+      out.add({'path': prefix, 'const': node['const']});
+      return;
+    }
+    final props = (node['properties'] as Map?)?.cast<String, dynamic>() ?? {};
+    for (final e in props.entries) {
+      final sub = (e.value as Map).cast<String, dynamic>();
+      final next = prefix.isEmpty ? e.key : '$prefix.${e.key}';
+      _collectConstConditions(sub, next, out);
+    }
+  }
+
+  void _collectRequiredTargets(Map<String, dynamic> node, String prefix, List<String> out) {
+    final req = (node['required'] as List?)?.cast<String>() ?? const [];
+    for (final r in req) {
+      out.add(prefix.isEmpty ? r : '$prefix.$r');
+    }
+    final props = (node['properties'] as Map?)?.cast<String, dynamic>() ?? {};
+    for (final e in props.entries) {
+      final sub = (e.value as Map).cast<String, dynamic>();
+      final next = prefix.isEmpty ? e.key : '$prefix.${e.key}';
+      _collectRequiredTargets(sub, next, out);
+    }
+  }
+
+  void _applyVisibility(List<InterviewPrompt> prompts, List<_VisRule> rules) {
+    final byId = {for (final p in prompts) p.id: p};
+    for (final r in rules) {
+      final p = byId[r.targetId];
+      if (p == null) continue;
+      final orig = p.visibleIf;
+      final visible = (Map<String, dynamic> a) {
+        final v = a[r.dependsOn];
+        final hit = v == r.equalsValue;
+        if (orig != null) {
+          return hit && orig(a);
+        }
+        return hit;
+      };
+      // Replace with a new prompt instance carrying visibleIf
+      byId[r.targetId] = InterviewPrompt(
+        id: p.id,
+        title: p.title,
+        help: p.help,
+        type: p.type,
+        required: p.required,
+        options: p.options,
+        minItems: p.minItems,
+        maxItems: p.maxItems,
+        isArray: p.isArray,
+        dependsOn: r.dependsOn,
+        visibleIf: visible,
+      );
+    }
+
+    // Rebuild ordered list in place
+    prompts
+      ..clear()
+      ..addAll(byId.values);
+  }
+}
+
+class _VisRule {
+  final String targetId;
+  final String dependsOn;
+  final dynamic equalsValue;
+  _VisRule({required this.targetId, required this.dependsOn, required this.equalsValue});
+}
+
+String _labelize(String v) {
+  return v
+      .replaceAllMapped(RegExp(r'([a-z])([A-Z])'), (m) => '${m[1]} ${m[2]}')
+      .replaceAll('_', ' ')
+      .replaceAll('Plus', '+')
+      .replaceAll('kinda', 'kind of')
+      .trim();
+}
+

--- a/colrvia5-main/pubspec.yaml
+++ b/colrvia5-main/pubspec.yaml
@@ -68,5 +68,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/documents/
-    # Optional if you plan to compile from JSON at runtime later:
-    # - assets/schemas/single-room-color-intake.json
+    - assets/schemas/single-room-color-intake.json


### PR DESCRIPTION
## Summary
- compile interview prompts from JSON schema at runtime
- load schema asynchronously in InterviewScreen with fallback to demo prompts
- add schema asset and InterviewEngine factory for injected prompts

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89f7f204c832290b8b08e1be605eb