### PR TITLE
Enable inline prompt editing on interview review

### DIFF
--- a/colrvia5-main/lib/screens/interview_review_screen.dart
+++ b/colrvia5-main/lib/screens/interview_review_screen.dart
@@ -20,52 +20,72 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
   void initState() {
     super.initState();
     _answers = Map.of(widget.engine.answers);
+    widget.engine.addListener(_onEngine);
+  }
+
+  @override
+  void dispose() {
+    widget.engine.removeListener(_onEngine);
+    super.dispose();
+  }
+
+  void _onEngine() {
+    // Keep local snapshot in sync (e.g., when branching changes visibility)
+    setState(() => _answers = Map.of(widget.engine.answers));
   }
 
   // Required prompts are those marked required & visible under current answers
   List<InterviewPrompt> _missingRequired() {
-    final visibleRequired =
-        widget.engine.visiblePrompts.where((p) => p.required).toList();
+    final visibleRequired = widget.engine.visiblePrompts.where((p) => p.required).toList();
     final missing = <InterviewPrompt>[];
     for (final p in visibleRequired) {
       final v = _answers[p.id];
-      if (v == null) {
-        missing.add(p);
-        continue;
-      }
-      if (v is String && v.trim().isEmpty) {
-        missing.add(p);
-        continue;
-      }
-      if (v is List && v.isEmpty) {
-        missing.add(p);
-        continue;
-      }
+      if (v == null) { missing.add(p); continue; }
+      if (v is String && v.trim().isEmpty) { missing.add(p); continue; }
+      if (v is List && v.isEmpty) { missing.add(p); continue; }
     }
     return missing;
   }
 
   Future<void> _generate() async {
-    // Persist and advance the journey
     await JourneyService.instance.setArtifact('answers', _answers);
-    await AnalyticsService.instance
-        .logEvent('interview_review_confirmed');
+    await AnalyticsService.instance.logEvent('interview_review_confirmed');
     await JourneyService.instance.completeCurrentStep();
-
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Nice! Generating your palette…')),
       );
-      Navigator.of(context).maybePop(); // back to Guided timeline
-      Navigator.of(context).maybePop(); // close InterviewScreen if still on stack
+      Navigator.of(context).maybePop();
+      Navigator.of(context).maybePop();
     }
   }
 
   void _editInChat(String id) {
-    Navigator.of(context).pop({'jumpTo': id}); // signal parent to deep-link back
+    Navigator.of(context).pop({'jumpTo': id});
   }
 
-  Widget _section(String title, List<_Row> rows) {
+  Future<void> _editInline(String id) async {
+    final prompt = widget.engine.byId(id);
+    if (prompt == null) return;
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (ctx) => Padding(
+        padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
+        child: _PromptEditorSheet(
+          prompt: prompt,
+          initialValue: _answers[id],
+          onSave: (val) {
+            widget.engine.setAnswer(id, val);
+            setState(() => _answers = Map.of(widget.engine.answers));
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title, List<_Row> rows, {bool editable = true}) {
     if (rows.isEmpty) return const SizedBox.shrink();
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
@@ -76,24 +96,36 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
           children: [
             Text(title, style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
-            for (final r in rows) _rowTile(r),
+            for (final r in rows) _rowTile(r, editable: editable),
           ],
         ),
       ),
     );
   }
 
-  Widget _rowTile(_Row r) {
+  Widget _rowTile(_Row r, {bool editable = true}) {
     final value = r.displayValue;
     return ListTile(
       contentPadding: EdgeInsets.zero,
       dense: true,
       title: Text(r.label),
       subtitle: value.isEmpty ? const Text('—') : Text(value),
-      trailing: TextButton.icon(
-        onPressed: () => _editInChat(r.id),
-        icon: const Icon(Icons.edit_outlined),
-        label: const Text('Edit'),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (editable)
+            TextButton.icon(
+              onPressed: () => _editInline(r.id),
+              icon: const Icon(Icons.tune_outlined),
+              label: const Text('Quick edit'),
+            ),
+          const SizedBox(width: 8),
+          TextButton.icon(
+            onPressed: () => _editInChat(r.id),
+            icon: const Icon(Icons.edit_outlined),
+            label: const Text('Edit in chat'),
+          ),
+        ],
       ),
     );
   }
@@ -104,18 +136,11 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
       if (p.options.isEmpty) {
         return value.join(', ');
       }
-      return value
-          .map((v) => p.options
-              .firstWhere((o) => o.value == v, orElse: () => p.options.first)
-              .label)
-          .join(', ');
+      return value.map((v) => p.options.firstWhere((o) => o.value == v, orElse: () => p.options.first).label).join(', ');
     }
     if (value is String) {
       if (p.options.isEmpty) return value;
-      final opt = p.options
-          .where((o) => o.value == value)
-          .cast<InterviewPromptOption?>()
-          .firstWhere((e) => e != null, orElse: () => null);
+      final opt = p.options.where((o) => o.value == value).cast<InterviewPromptOption?>().firstWhere((e) => e != null, orElse: () => null);
       return opt?.label ?? value;
     }
     return value.toString();
@@ -140,114 +165,39 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
     final roomType = _answers['roomType'] as String?;
 
     final core = _rowsForIds([
-      'roomType',
-      'usage',
-      'moodWords',
-      'daytimeBrightness',
-      'bulbColor',
-      'boldDarkerSpot',
-      'brandPreference',
+      'roomType','usage','moodWords','daytimeBrightness','bulbColor','boldDarkerSpot','brandPreference',
     ]);
 
     final existing = _rowsForIds([
-      'existingElements.floorLook',
-      'existingElements.floorLookOtherNote',
-      'existingElements.bigThingsToMatch',
-      'existingElements.metals',
-      'existingElements.mustStaySame',
+      'existingElements.floorLook','existingElements.floorLookOtherNote','existingElements.bigThingsToMatch','existingElements.metals','existingElements.mustStaySame',
     ]);
 
     final comfort = _rowsForIds([
-      'colorComfort.overallVibe',
-      'colorComfort.warmCoolFeel',
-      'colorComfort.contrastLevel',
-      'colorComfort.popColor',
+      'colorComfort.overallVibe','colorComfort.warmCoolFeel','colorComfort.contrastLevel','colorComfort.popColor',
     ]);
 
     final finishes = _rowsForIds([
-      'finishes.wallsFinishPriority',
-      'finishes.trimDoorsFinish',
-      'finishes.specialNeeds',
+      'finishes.wallsFinishPriority','finishes.trimDoorsFinish','finishes.specialNeeds',
     ]);
 
     // Room-specific blocks
     final roomMap = <String, List<String>>{
-      'kitchen': [
-        'roomSpecific.cabinets',
-        'roomSpecific.cabinetsCurrentColor',
-        'roomSpecific.island',
-        'roomSpecific.countertopsDescription',
-        'roomSpecific.backsplash',
-        'roomSpecific.backsplashDescribe',
-        'roomSpecific.appliances',
-        'roomSpecific.wallFeel',
-        'roomSpecific.darkerSpots',
-      ],
-      'bathroom': [
-        'roomSpecific.tileMainColor',
-        'roomSpecific.tileColorWhich',
-        'roomSpecific.vanityTop',
-        'roomSpecific.showerSteamLevel',
-        'roomSpecific.fixtureMetal',
-        'roomSpecific.goal',
-        'roomSpecific.darkerVanityOrDoor',
-      ],
-      'bedroom': [
-        'roomSpecific.sleepFeel',
-        'roomSpecific.beddingColors',
-        'roomSpecific.headboard',
-        'roomSpecific.windowTreatments',
-        'roomSpecific.darkerWallBehindBed',
-      ],
-      'livingRoom': [
-        'roomSpecific.sofaColor',
-        'roomSpecific.rugMainColors',
-        'roomSpecific.fireplace',
-        'roomSpecific.fireplaceDetail',
-        'roomSpecific.tvWall',
-        'roomSpecific.builtInsOrDoorColor',
-      ],
-      'diningRoom': [
-        'roomSpecific.tableWoodTone',
-        'roomSpecific.chairs',
-        'roomSpecific.lightFixtureMetal',
-        'roomSpecific.feeling',
-        'roomSpecific.darkerBelowOrOneWall',
-      ],
-      'office': [
-        'roomSpecific.workMood',
-        'roomSpecific.screenGlare',
-        'roomSpecific.deeperLibraryWallsOk',
-        'roomSpecific.colorBookshelvesOrBuiltIns',
-      ],
-      'kidsRoom': [
-        'roomSpecific.mood',
-        'roomSpecific.mainFabricToyColors',
-        'roomSpecific.superWipeableWalls',
-        'roomSpecific.smallColorPopOk',
-      ],
-      'laundryMudroom': [
-        'roomSpecific.traffic',
-        'roomSpecific.cabinetsShelving',
-        'roomSpecific.cabinetsColor',
-        'roomSpecific.hideDirtOrBrightClean',
-        'roomSpecific.doorColorMomentOk',
-      ],
-      'entryHall': [
-        'roomSpecific.naturalLight',
-        'roomSpecific.stairsBanister',
-        'roomSpecific.woodTone',
-        'roomSpecific.paintColor',
-        'roomSpecific.feel',
-        'roomSpecific.doorColorMoment',
-      ],
+      'kitchen': ['roomSpecific.cabinets','roomSpecific.cabinetsCurrentColor','roomSpecific.island','roomSpecific.countertopsDescription','roomSpecific.backsplash','roomSpecific.backsplashDescribe','roomSpecific.appliances','roomSpecific.wallFeel','roomSpecific.darkerSpots'],
+      'bathroom': ['roomSpecific.tileMainColor','roomSpecific.tileColorWhich','roomSpecific.vanityTop','roomSpecific.showerSteamLevel','roomSpecific.fixtureMetal','roomSpecific.goal','roomSpecific.darkerVanityOrDoor'],
+      'bedroom': ['roomSpecific.sleepFeel','roomSpecific.beddingColors','roomSpecific.headboard','roomSpecific.windowTreatments','roomSpecific.darkerWallBehindBed'],
+      'livingRoom': ['roomSpecific.sofaColor','roomSpecific.rugMainColors','roomSpecific.fireplace','roomSpecific.fireplaceDetail','roomSpecific.tvWall','roomSpecific.builtInsOrDoorColor'],
+      'diningRoom': ['roomSpecific.tableWoodTone','roomSpecific.chairs','roomSpecific.lightFixtureMetal','roomSpecific.feeling','roomSpecific.darkerBelowOrOneWall'],
+      'office': ['roomSpecific.workMood','roomSpecific.screenGlare','roomSpecific.deeperLibraryWallsOk','roomSpecific.colorBookshelvesOrBuiltIns'],
+      'kidsRoom': ['roomSpecific.mood','roomSpecific.mainFabricToyColors','roomSpecific.superWipeableWalls','roomSpecific.smallColorPopOk'],
+      'laundryMudroom': ['roomSpecific.traffic','roomSpecific.cabinetsShelving','roomSpecific.cabinetsColor','roomSpecific.hideDirtOrBrightClean','roomSpecific.doorColorMomentOk'],
+      'entryHall': ['roomSpecific.naturalLight','roomSpecific.stairsBanister','roomSpecific.woodTone','roomSpecific.paintColor','roomSpecific.feel','roomSpecific.doorColorMoment'],
       'other': ['roomSpecific.describeRoom'],
     };
 
     final roomRows = _rowsForIds(roomMap[roomType] ?? const []);
 
     // Guardrails and Photos
-    final guardrails = _rowsForIds(['guardrails.mustHaves', 'guardrails.hardNos']);
+    final guardrails = _rowsForIds(['guardrails.mustHaves','guardrails.hardNos']);
     final photos = _rowsForIds(['photos']);
 
     final missing = _missingRequired();
@@ -266,31 +216,23 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        'Missing required',
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleMedium
-                            ?.copyWith(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onErrorContainer),
-                      ),
+                      Text('Missing required', style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Theme.of(context).colorScheme.onErrorContainer)),
                       const SizedBox(height: 8),
                       for (final p in missing)
                         ListTile(
                           contentPadding: EdgeInsets.zero,
                           dense: true,
                           title: Text(p.title),
-                          trailing: TextButton(
-                            onPressed: () => _editInChat(p.id),
-                            child: const Text('Fill now'),
-                          ),
+                          trailing: Wrap(spacing: 8, children: [
+                            TextButton(onPressed: () => _editInline(p.id), child: const Text('Quick edit')),
+                            TextButton(onPressed: () => _editInChat(p.id), child: const Text('Edit in chat')),
+                          ]),
                         ),
                     ],
                   ),
                 ),
               ),
+
             _section('Basics', core),
             if (roomRows.isNotEmpty) _section('Room details', roomRows),
             _section('Existing elements', existing),
@@ -298,6 +240,7 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
             _section('Finishes', finishes),
             _section('Guardrails', guardrails),
             _photosSection(photos),
+
             const SizedBox(height: 16),
             FilledButton.icon(
               onPressed: missing.isNotEmpty ? null : _generate,
@@ -312,11 +255,7 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
 
   Widget _photosSection(List<_Row> rows) {
     if (rows.isEmpty) return const SizedBox.shrink();
-    final photoRow = rows.firstWhere((r) => r.id == 'photos',
-        orElse: () =>
-            _Row(id: 'photos', label: 'Photos', displayValue: ''));
-
-    final val = widget.engine.answers['photos'];
+    final val = _answers['photos'];
     final uris = (val is List) ? val.cast<String>() : const <String>[];
 
     return Card(
@@ -333,22 +272,26 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
-                children: uris
-                    .map((u) => ActionChip(
-                          label: Text(_truncate(u)),
-                          onPressed: () => launchUrl(Uri.parse(u),
-                              mode: LaunchMode.externalApplication),
-                        ))
-                    .toList(),
+                children: uris.map((u) => ActionChip(
+                  label: Text(_truncate(u)),
+                  onPressed: () => launchUrl(Uri.parse(u), mode: LaunchMode.externalApplication),
+                )).toList(),
               ),
-            const SizedBox(height: 4),
+            const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerRight,
-              child: TextButton.icon(
-                onPressed: () => _editInChat('photos'),
-                icon: const Icon(Icons.edit_outlined),
-                label: const Text('Edit'),
-              ),
+              child: Wrap(spacing: 8, children: [
+                TextButton.icon(
+                  onPressed: () => _editInline('photos'),
+                  icon: const Icon(Icons.tune_outlined),
+                  label: const Text('Quick edit'),
+                ),
+                TextButton.icon(
+                  onPressed: () => _editInChat('photos'),
+                  icon: const Icon(Icons.edit_outlined),
+                  label: const Text('Edit in chat'),
+                ),
+              ]),
             ),
           ],
         ),
@@ -367,4 +310,251 @@ class _Row {
   final String label;
   final String displayValue;
   _Row({required this.id, required this.label, required this.displayValue});
+}
+
+// === Bottom sheet editor ===
+class _PromptEditorSheet extends StatefulWidget {
+  final InterviewPrompt prompt;
+  final dynamic initialValue;
+  final void Function(dynamic) onSave;
+  const _PromptEditorSheet({required this.prompt, required this.initialValue, required this.onSave});
+
+  @override
+  State<_PromptEditorSheet> createState() => _PromptEditorSheetState();
+}
+
+class _PromptEditorSheetState extends State<_PromptEditorSheet> {
+  late dynamic _value;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = _clone(widget.initialValue);
+  }
+
+  dynamic _clone(dynamic v) {
+    if (v is List) return [...v];
+    return v;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final p = widget.prompt;
+    final title = p.title;
+
+    Widget editor;
+    switch (p.type) {
+      case InterviewPromptType.singleSelect:
+        editor = _SingleSelectEditor(prompt: p, value: (_value as String?), onChanged: (v) => setState(() => _value = v));
+        break;
+      case InterviewPromptType.multiSelect:
+        if (p.options.isEmpty) {
+          editor = _FreeListEditor(values: (_value as List?)?.cast<String>() ?? const [], onChanged: (v) => setState(() => _value = v), minItems: p.minItems, maxItems: p.maxItems);
+        } else {
+          editor = _MultiSelectEnumEditor(prompt: p, values: (_value as List?)?.cast<String>() ?? const [], onChanged: (v) => setState(() => _value = v), minItems: p.minItems, maxItems: p.maxItems);
+        }
+        break;
+      case InterviewPromptType.freeText:
+        editor = _FreeTextEditor(value: (_value as String?) ?? '', onChanged: (v) => setState(() => _value = v));
+        break;
+      case InterviewPromptType.yesNo:
+        editor = _YesNoEditor(value: (_value as String?), onChanged: (v) => setState(() => _value = v));
+        break;
+    }
+
+    final canSave = () {
+      if (!p.required) return true;
+      if (_value == null) return false;
+      if (_value is String && (_value as String).trim().isEmpty) return false;
+      if (_value is List && (_value as List).isEmpty) return false;
+      return true;
+    }();
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            editor,
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                OutlinedButton.icon(
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  icon: const Icon(Icons.close),
+                  label: const Text('Cancel'),
+                ),
+                const Spacer(),
+                FilledButton.icon(
+                  onPressed: canSave ? () { widget.onSave(_value); Navigator.of(context).maybePop(); } : null,
+                  icon: const Icon(Icons.check),
+                  label: const Text('Save'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SingleSelectEditor extends StatelessWidget {
+  final InterviewPrompt prompt;
+  final String? value;
+  final ValueChanged<String?> onChanged;
+  const _SingleSelectEditor({required this.prompt, required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: prompt.options.map((o) => RadioListTile<String>(
+        value: o.value,
+        groupValue: value,
+        onChanged: onChanged,
+        title: Text(o.label),
+      )).toList(),
+    );
+  }
+}
+
+class _MultiSelectEnumEditor extends StatefulWidget {
+  final InterviewPrompt prompt;
+  final List<String> values;
+  final ValueChanged<List<String>> onChanged;
+  final int? minItems;
+  final int? maxItems;
+  const _MultiSelectEnumEditor({required this.prompt, required this.values, required this.onChanged, this.minItems, this.maxItems});
+
+  @override
+  State<_MultiSelectEnumEditor> createState() => _MultiSelectEnumEditorState();
+}
+
+class _MultiSelectEnumEditorState extends State<_MultiSelectEnumEditor> {
+  late List<String> _selected = [...widget.values];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ...widget.prompt.options.map((o) => CheckboxListTile(
+              value: _selected.contains(o.value),
+              onChanged: (v) {
+                setState(() {
+                  if (v == true) {
+                    if (widget.maxItems == null || _selected.length < widget.maxItems!) {
+                      _selected.add(o.value);
+                    }
+                  } else {
+                    _selected.remove(o.value);
+                  }
+                });
+                widget.onChanged(_selected);
+              },
+              title: Text(o.label),
+            )),
+        const SizedBox(height: 4),
+        if (widget.maxItems != null)
+          Text('${_selected.length}/${widget.maxItems} selected', style: Theme.of(context).textTheme.bodySmall),
+      ],
+    );
+  }
+}
+
+class _FreeTextEditor extends StatefulWidget {
+  final String value;
+  final ValueChanged<String> onChanged;
+  const _FreeTextEditor({required this.value, required this.onChanged});
+
+  @override
+  State<_FreeTextEditor> createState() => _FreeTextEditorState();
+}
+
+class _FreeTextEditorState extends State<_FreeTextEditor> {
+  late final TextEditingController _c = TextEditingController(text: widget.value);
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _c,
+      minLines: 1,
+      maxLines: 4,
+      decoration: const InputDecoration(border: OutlineInputBorder(), hintText: 'Type your answer…'),
+      onChanged: widget.onChanged,
+    );
+  }
+}
+
+class _YesNoEditor extends StatelessWidget {
+  final String? value; // 'yes' | 'no'
+  final ValueChanged<String?> onChanged;
+  const _YesNoEditor({required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      RadioListTile<String>(value: 'yes', groupValue: value, onChanged: onChanged, title: const Text('Yes')),
+      RadioListTile<String>(value: 'no', groupValue: value, onChanged: onChanged, title: const Text('No')),
+    ]);
+  }
+}
+
+class _FreeListEditor extends StatefulWidget {
+  final List<String> values;
+  final ValueChanged<List<String>> onChanged;
+  final int? minItems;
+  final int? maxItems;
+  const _FreeListEditor({required this.values, required this.onChanged, this.minItems, this.maxItems});
+
+  @override
+  State<_FreeListEditor> createState() => _FreeListEditorState();
+}
+
+class _FreeListEditorState extends State<_FreeListEditor> {
+  late List<String> _vals = [...widget.values];
+  final _controller = TextEditingController();
+
+  void _add() {
+    final t = _controller.text.trim();
+    if (t.isEmpty) return;
+    if (widget.maxItems != null && _vals.length >= widget.maxItems!) return;
+    setState(() { _vals.add(t); });
+    widget.onChanged(_vals);
+    _controller.clear();
+  }
+
+  void _remove(String v) {
+    setState(() { _vals.remove(v); });
+    widget.onChanged(_vals);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: _vals.map((v) => InputChip(
+            label: Text(v),
+            onDeleted: () => _remove(v),
+          )).toList(),
+        ),
+        const SizedBox(height: 8),
+        Row(children: [
+          Expanded(child: TextField(controller: _controller, decoration: const InputDecoration(hintText: 'Add item…', border: OutlineInputBorder()))),
+          const SizedBox(width: 8),
+          FilledButton.icon(onPressed: _add, icon: const Icon(Icons.add), label: const Text('Add')),
+        ]),
+        const SizedBox(height: 4),
+        if (widget.maxItems != null)
+          Text('${_vals.length}/${widget.maxItems} items', style: Theme.of(context).textTheme.bodySmall),
+      ],
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Replace interview review screen with version that supports quick inline editing via a bottom sheet
- Add prompt-specific editors (single-select, multi-select, free text, yes/no, free-form list)
- Sync updates with InterviewEngine and show required-field warnings

## Testing
- `dart format lib/screens/interview_review_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3a7a7288322992b6846becc23ae