### PR TITLE
feat: add palette reveal screen and utilities

### DIFF
--- a/colrvia5-main/lib/models/palette_models.dart
+++ b/colrvia5-main/lib/models/palette_models.dart
@@ -1,0 +1,62 @@
+class PaintColor {
+  final String name; // e.g., "Pure White"
+  final String code; // hex like #F8F8F6 or brand code
+  final double? lrv; // 0..100 if available
+  final String? undertone; // e.g., "warm", "cool", "green-gray"
+  const PaintColor({required this.name, required this.code, this.lrv, this.undertone});
+
+  factory PaintColor.fromJson(Map<String, dynamic> j) => PaintColor(
+        name: j['name'] ?? '',
+        code: (j['hex'] ?? j['code'] ?? '#000000').toString(),
+        lrv: j['LRV'] == null ? null : (j['LRV'] as num).toDouble(),
+        undertone: j['undertone'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'hex': code,
+        if (lrv != null) 'LRV': lrv,
+        if (undertone != null) 'undertone': undertone,
+      };
+}
+
+class PaletteRoles {
+  final PaintColor anchor; // main wall
+  final PaintColor secondary; // trim/ceiling or cabinets
+  final PaintColor accent; // door/built-ins/one wall
+  const PaletteRoles({required this.anchor, required this.secondary, required this.accent});
+
+  PaletteRoles copyWith({PaintColor? anchor, PaintColor? secondary, PaintColor? accent}) =>
+      PaletteRoles(anchor: anchor ?? this.anchor, secondary: secondary ?? this.secondary, accent: accent ?? this.accent);
+}
+
+class Palette {
+  final String brand; // SherwinWilliams, BenjaminMoore, Behr
+  final PaletteRoles roles;
+  final Map<String, dynamic>? rationale;
+  final String? id; // optional paletteId from backend
+
+  const Palette({required this.brand, required this.roles, this.rationale, this.id});
+
+  factory Palette.fromJson(Map<String, dynamic> j) {
+    final roles = j['roles'] as Map<String, dynamic>;
+    PaintColor _pc(String k) => PaintColor.fromJson((roles[k] as Map).cast<String, dynamic>());
+    return Palette(
+      brand: j['brand'] ?? 'SherwinWilliams',
+      roles: PaletteRoles(anchor: _pc('anchor'), secondary: _pc('secondary'), accent: _pc('accent')),
+      rationale: (j['rationale'] as Map?)?.cast<String, dynamic>(),
+      id: j['id'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'brand': brand,
+        'roles': {
+          'anchor': roles.anchor.toJson(),
+          'secondary': roles.secondary.toJson(),
+          'accent': roles.accent.toJson(),
+        },
+        if (rationale != null) 'rationale': rationale,
+        if (id != null) 'id': id,
+      };
+}

--- a/colrvia5-main/lib/screens/palette_reveal_screen.dart
+++ b/colrvia5-main/lib/screens/palette_reveal_screen.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import 'package:color_canvas/models/palette_models.dart';
+import 'package:color_canvas/services/contrast_utils.dart';
+import 'package:color_canvas/services/palette_suggestions_service.dart';
+import 'package:color_canvas/services/journey/journey_service.dart';
+
+class PaletteRevealScreen extends StatefulWidget {
+  final Map<String, dynamic>? paletteJson; // optional direct payload
+  const PaletteRevealScreen({super.key, this.paletteJson});
+
+  @override
+  State<PaletteRevealScreen> createState() => _PaletteRevealScreenState();
+}
+
+class _PaletteRevealScreenState extends State<PaletteRevealScreen> {
+  Palette? _palette;
+  bool _loading = true;
+  bool _saving = false;
+  String? _error;
+  List<PaintColor> _accentAlternates = [];
+  PaintColor? _accentPreview; // transient selection
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      Map<String, dynamic>? pjson = widget.paletteJson;
+      final art = JourneyService.instance.state.value?.artifacts;
+      pjson ??= (art?['palette'] as Map?)?.cast<String, dynamic>();
+      pjson ??= await _tryFetchById(art?['paletteId'] as String?);
+
+      if (pjson == null) throw Exception('No palette found in artifacts.');
+      final pal = Palette.fromJson(pjson);
+      setState(() => _palette = pal);
+      await _loadAlternates();
+    } catch (e) {
+      setState(() => _error = e.toString());
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<Map<String, dynamic>?> _tryFetchById(String? id) async {
+    if (id == null) return null;
+    // TODO: hook up PaletteService.getById(id). For now, return null.
+    return null;
+  }
+
+  Future<void> _loadAlternates() async {
+    if (_palette == null) return;
+    final answers = JourneyService.instance.state.value?.artifacts['answers'] as Map<String, dynamic>?;
+    final alts = await PaletteSuggestionsService.instance
+        .suggestAccentAlternatives(base: _palette!, answers: answers);
+    setState(() => _accentAlternates = alts);
+  }
+
+  Future<void> _applyAccent(PaintColor c) async {
+    if (_palette == null) return;
+    setState(() {
+      _accentPreview = c;
+      _saving = true;
+    });
+    final updated = _palette!.copyWith(roles: _palette!.roles.copyWith(accent: c));
+    await JourneyService.instance.setArtifact('palette', updated.toJson());
+    setState(() {
+      _palette = updated;
+      _saving = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    if (_error != null) {
+      return Scaffold(appBar: AppBar(title: const Text('Palette')), body: Center(child: Text(_error!)));
+    }
+    final pal = _palette!;
+
+    final anchor = pal.roles.anchor;
+    final secondary = pal.roles.secondary;
+    final accent = _accentPreview ?? pal.roles.accent;
+
+    final c1 = assessContrast(anchor.code, secondary.code); // wall vs trim
+    final c2 = assessContrast(anchor.code, accent.code); // wall vs accent
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Your palette')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text(pal.brand, style: Theme.of(context).textTheme.titleSmall),
+            const SizedBox(height: 12),
+            _roleRow(context, 'Anchor (walls)', anchor),
+            _roleRow(context, 'Secondary (trim/cabinets)', secondary),
+            _roleRow(context, 'Accent (door/built-ins)', accent),
+            const SizedBox(height: 12),
+            _contrastCard('Walls vs Trim', anchor.code, secondary.code, c1),
+            _contrastCard('Walls vs Accent', anchor.code, accent.code, c2),
+            const SizedBox(height: 12),
+            _rationale(pal),
+            const SizedBox(height: 16),
+            _swapAccentSection(context, pal, accent),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: _saving ? null : _goVisualizer,
+              icon: const Icon(Icons.photo_size_select_large_outlined),
+              label: const Text('See it on your walls'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _roleRow(BuildContext context, String label, PaintColor c) {
+    return Card(
+      child: ListTile(
+        title: Text(label),
+        subtitle: Text(
+            '${c.name} • ${c.code}${c.lrv != null ? ' • LRV ${c.lrv!.toStringAsFixed(0)}' : ''}${c.undertone != null ? ' • ${c.undertone}' : ''}'),
+        trailing: Container(
+          width: 56,
+          height: 28,
+          decoration: BoxDecoration(
+            color: _parseColor(c.code),
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(color: Colors.black12),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _contrastCard(String title, String aHex, String bHex, ContrastReport r) {
+    final a = _parseColor(aHex), b = _parseColor(bHex);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(children: [
+              Text(title, style: Theme.of(context).textTheme.titleMedium),
+              const Spacer(),
+              _badge(r.grade),
+            ]),
+            const SizedBox(height: 8),
+            Row(children: [
+              _swatch(a),
+              const SizedBox(width: 8),
+              _swatch(b),
+              const SizedBox(width: 12),
+              Text('${r.ratio.toStringAsFixed(1)}:1  •  ${r.hint}'),
+            ]),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _rationale(Palette p) {
+    final r = p.rationale ?? const {};
+    if (r.isEmpty) return const SizedBox.shrink();
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Why this works', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 4),
+            if (r['lighting'] != null) Text('Lighting: ${r['lighting']}'),
+            if (r['mood'] != null) Text('Mood: ${r['mood']}'),
+            if (r['floors'] != null) Text('Floors: ${r['floors']}'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _swapAccentSection(BuildContext context, Palette pal, PaintColor current) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(children: [
+              Text('Try a different accent', style: Theme.of(context).textTheme.titleMedium),
+              const Spacer(),
+              if (_saving)
+                const Padding(
+                    padding: EdgeInsets.only(right: 8),
+                    child: SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))),
+            ]),
+            const SizedBox(height: 8),
+            Wrap(spacing: 8, runSpacing: 8, children: [
+              _accentChip(current, label: 'Current', onTap: null),
+              for (final c in _accentAlternates) _accentChip(c, onTap: () => _applyAccent(c)),
+            ]),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _accentChip(PaintColor c, {VoidCallback? onTap, String? label}) {
+    return ActionChip(
+      avatar: Container(
+        width: 18,
+        height: 18,
+        decoration: BoxDecoration(
+          color: _parseColor(c.code),
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.black12),
+        ),
+      ),
+      label: Text(label ?? c.name),
+      onPressed: onTap,
+    );
+  }
+
+  Widget _badge(String grade) {
+    Color bg;
+    Color fg;
+    switch (grade) {
+      case 'High':
+        bg = Colors.green.shade100;
+        fg = Colors.green.shade900;
+        break;
+      case 'OK':
+        bg = Colors.blue.shade100;
+        fg = Colors.blue.shade900;
+        break;
+      case 'Soft':
+        bg = Colors.amber.shade100;
+        fg = Colors.amber.shade900;
+        break;
+      default:
+        bg = Colors.red.shade100;
+        fg = Colors.red.shade900;
+        break;
+    }
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(color: bg, borderRadius: BorderRadius.circular(999)),
+      child: Text(grade, style: TextStyle(color: fg)),
+    );
+  }
+
+  Widget _swatch(Color c) => Container(
+        width: 32,
+        height: 20,
+        decoration: BoxDecoration(
+          color: c,
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: Colors.black12),
+        ),
+      );
+
+  Color _parseColor(String hex) {
+    String h = hex.replaceAll('#', '');
+    if (h.length == 3) {
+      h = '${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}';
+    }
+    return Color(int.parse('FF$h', radix: 16));
+  }
+
+  void _goVisualizer() {
+    // Let your Guided flow route to the Visualizer step. Here we just pop.
+    Navigator.of(context).maybePop();
+  }
+}

--- a/colrvia5-main/lib/services/contrast_utils.dart
+++ b/colrvia5-main/lib/services/contrast_utils.dart
@@ -1,0 +1,53 @@
+import 'dart:math';
+
+class ContrastReport {
+  final double ratio; // e.g., 4.5
+  final String grade; // High / OK / Low
+  final String hint; // guidance
+  const ContrastReport({required this.ratio, required this.grade, required this.hint});
+}
+
+// Parse #RRGGBB → linearized luminance
+double _luminanceFromHex(String hex) {
+  String h = hex.trim();
+  if (!h.startsWith('#')) h = '#$h';
+  if (h.length == 4) {
+    // #RGB → #RRGGBB
+    h = '#'
+        '${h[1]}${h[1]}'
+        '${h[2]}${h[2]}'
+        '${h[3]}${h[3]}';
+  }
+  int r = int.parse(h.substring(1, 3), radix: 16);
+  int g = int.parse(h.substring(3, 5), radix: 16);
+  int b = int.parse(h.substring(5, 7), radix: 16);
+
+  double _lin(int c) {
+    double s = c / 255.0;
+    return s <= 0.03928 ? s / 12.92 : pow((s + 0.055) / 1.055, 2.4).toDouble();
+  }
+
+  final rl = _lin(r), gl = _lin(g), bl = _lin(b);
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+/// WCAG contrast ratio between two hex colors
+double contrastRatio(String hex1, String hex2) {
+  final l1 = _luminanceFromHex(hex1);
+  final l2 = _luminanceFromHex(hex2);
+  final hi = max(l1, l2), lo = min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+ContrastReport assessContrast(String a, String b) {
+  final r = double.parse(contrastRatio(a, b).toStringAsFixed(2));
+  if (r >= 7.0) {
+    return ContrastReport(ratio: r, grade: 'High', hint: 'Crisp separation — great for trim & walls.');
+  } else if (r >= 4.5) {
+    return ContrastReport(ratio: r, grade: 'OK', hint: 'Comfortable for most walls/trim in natural light.');
+  } else if (r >= 3.0) {
+    return ContrastReport(ratio: r, grade: 'Soft', hint: 'Soft contrast — works for calm spaces or low-gloss finishes.');
+  } else {
+    return ContrastReport(ratio: r, grade: 'Low', hint: 'Very low contrast — consider lightening/darkening one color.');
+  }
+}

--- a/colrvia5-main/lib/services/palette_suggestions_service.dart
+++ b/colrvia5-main/lib/services/palette_suggestions_service.dart
@@ -1,0 +1,110 @@
+import 'dart:math';
+import 'package:color_canvas/models/palette_models.dart';
+
+/// Replace this with your Cloud Function / AI endpoint later.
+/// For now we create 2–3 accent variants by nudging lightness while preserving undertone label.
+class PaletteSuggestionsService {
+  static final PaletteSuggestionsService instance = PaletteSuggestionsService._();
+  PaletteSuggestionsService._();
+
+  Future<List<PaintColor>> suggestAccentAlternatives({required Palette base, Map<String, dynamic>? answers}) async {
+    final accent = base.roles.accent;
+    final List<PaintColor> out = [];
+    // Generate light/dark neighbors
+    out.add(_nudgeLightness(accent, +0.10));
+    out.add(_nudgeLightness(accent, -0.10));
+    // If we have mood/lighting, bias an extra option
+    final mood = (answers?['moodWords'] as List?)?.cast<String>() ?? const [];
+    if (mood.contains('moody')) {
+      out.add(_nudgeLightness(accent, -0.18));
+    } else {
+      out.add(_nudgeLightness(accent, +0.18));
+    }
+    // Deduplicate by hex
+    final seen = <String>{};
+    return out.where((c) => seen.add(c.code.toUpperCase())).toList();
+  }
+
+  PaintColor _nudgeLightness(PaintColor c, double delta) {
+    final hsl = _hexToHsl(c.code);
+    final l = (hsl.l + delta).clamp(0.05, 0.95);
+    final hex = _hslToHex(HSLColor(hue: hsl.h, saturation: hsl.s, lightness: l));
+    final lrv = c.lrv == null ? null : (c.lrv! * (1 + delta * 0.6)).clamp(0, 100);
+    return PaintColor(name: c.name, code: hex, lrv: lrv?.toDouble(), undertone: c.undertone);
+  }
+
+  // --- tiny HSL helpers ---
+  HSLColor _hexToHsl(String hex) {
+    String h = hex.startsWith('#') ? hex.substring(1) : hex;
+    if (h.length == 3) {
+      h = '${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}';
+    }
+    final r = int.parse(h.substring(0, 2), radix: 16) / 255.0;
+    final g = int.parse(h.substring(2, 4), radix: 16) / 255.0;
+    final b = int.parse(h.substring(4, 6), radix: 16) / 255.0;
+    final maxc = [r, g, b].reduce(max);
+    final minc = [r, g, b].reduce(min);
+    final l = (maxc + minc) / 2.0;
+    double hDeg, s;
+    if (maxc == minc) {
+      hDeg = 0;
+      s = 0;
+    } else {
+      final d = maxc - minc;
+      s = l > 0.5 ? d / (2 - maxc - minc) : d / (maxc + minc);
+      if (maxc == r) {
+        hDeg = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+      } else if (maxc == g) {
+        hDeg = ((b - r) / d + 2) * 60;
+      } else {
+        hDeg = ((r - g) / d + 4) * 60;
+      }
+    }
+    return HSLColor(hue: hDeg, saturation: s, lightness: l);
+  }
+
+  String _hslToHex(HSLColor hsl) {
+    final c = (1 - (2 * hsl.lightness - 1).abs()) * hsl.saturation;
+    final x = c * (1 - (((hsl.hue / 60) % 2) - 1).abs());
+    final m = hsl.lightness - c / 2;
+    double r = 0, g = 0, b = 0;
+    final h = hsl.hue;
+    if (h < 60) {
+      r = c;
+      g = x;
+      b = 0;
+    } else if (h < 120) {
+      r = x;
+      g = c;
+      b = 0;
+    } else if (h < 180) {
+      r = 0;
+      g = c;
+      b = x;
+    } else if (h < 240) {
+      r = 0;
+      g = x;
+      b = c;
+    } else if (h < 300) {
+      r = x;
+      g = 0;
+      b = c;
+    } else {
+      r = c;
+      g = 0;
+      b = x;
+    }
+    int ri = ((r + m) * 255).round();
+    int gi = ((g + m) * 255).round();
+    int bi = ((b + m) * 255).round();
+    String hh(int v) => v.toRadixString(16).padLeft(2, '0');
+    return '#${hh(ri)}${hh(gi)}${hh(bi)}'.toUpperCase();
+  }
+}
+
+class HSLColor {
+  final double hue; // 0..360
+  final double saturation; // 0..1
+  final double lightness; // 0..1
+  HSLColor({required this.hue, required this.saturation, required this.lightness});
+}


### PR DESCRIPTION
## Summary
- add models for paint colors and palettes
- compute WCAG contrast ratios
- provide palette reveal screen with accent swap suggestions

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a52023348322bef5e787f654b9bf