### PR TITLE
fix: add voice assistant dependencies

### DIFF
--- a/colrvia5-main/lib/services/voice_assistant.dart
+++ b/colrvia5-main/lib/services/voice_assistant.dart
@@ -2,12 +2,12 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
-import 'package:flutter_tts/flutter_tts.dart';
+import 'package:flutter_tts/flutter_tts.dart' as tts;
 
 /// Simple voice layer that powers "AI Talk" mode: Listen → Think → Speak.
 class VoiceAssistant extends ChangeNotifier {
   final stt.SpeechToText _speech = stt.SpeechToText();
-  final FlutterTts _tts = FlutterTts();
+  final tts.FlutterTts _tts = tts.FlutterTts();
 
   bool _listening = false;
   bool get isListening => _listening;
@@ -39,11 +39,8 @@ class VoiceAssistant extends ChangeNotifier {
       listenMode: stt.ListenMode.dictation,
       onResult: (res) {
         last = res.recognizedWords;
-        if (res.finalResult) {
-        if (!completer.isCompleted) {
-  completer.complete(last.trim().isEmpty ? null : last.trim());
-}
-
+        if (res.finalResult && !completer.isCompleted) {
+          completer.complete(last.trim().isEmpty ? null : last.trim());
         }
       },
     );

--- a/colrvia5-main/pubspec.yaml
+++ b/colrvia5-main/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   firebase_remote_config: ^6.0.0
   timezone: ^0.10.1
   webview_flutter: ^4.4.1
+
+  # Voice assistant dependencies
   speech_to_text: ^7.3.0
   flutter_tts: ^4.2.3
 


### PR DESCRIPTION
## Summary
- alias text-to-speech import and streamline speech result handling
- document speech packages in pubspec

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8abf9b888832286fbbf1d95736f7b