### PR TITLE
feat: integrate analytics and alt visualizer updates

### DIFF
--- a/colrvia5-main/lib/screens/interview_review_screen.dart
+++ b/colrvia5-main/lib/screens/interview_review_screen.dart
@@ -116,16 +116,24 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (editable)
-            TextButton.icon(
-              onPressed: () => _editInline(r.id),
-              icon: const Icon(Icons.tune_outlined),
-              label: const Text('Quick edit'),
+            Semantics(
+              button: true,
+              label: 'Quick edit \\${r.label}',
+              child: TextButton.icon(
+                onPressed: () => _editInline(r.id),
+                icon: const Icon(Icons.tune_outlined),
+                label: const Text('Quick edit'),
+              ),
             ),
-          const SizedBox(width: 8),
-          TextButton.icon(
-            onPressed: () => _editInChat(r.id),
-            icon: const Icon(Icons.edit_outlined),
-            label: const Text('Edit in chat'),
+          if (editable) const SizedBox(width: 8),
+          Semantics(
+            button: true,
+            label: 'Edit \\${r.label} in chat',
+            child: TextButton.icon(
+              onPressed: () => _editInChat(r.id),
+              icon: const Icon(Icons.edit_outlined),
+              label: const Text('Edit in chat'),
+            ),
           ),
         ],
       ),

--- a/colrvia5-main/lib/screens/palette_reveal_screen.dart
+++ b/colrvia5-main/lib/screens/palette_reveal_screen.dart
@@ -76,7 +76,21 @@ class _PaletteRevealScreenState extends State<PaletteRevealScreen> {
   @override
   Widget build(BuildContext context) {
     if (_loading) {
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+      return Scaffold(
+        appBar: AppBar(title: const Text('Your palette')),
+        body: ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: 4,
+          itemBuilder: (_, i) => Container(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            height: i == 3 ? 120 : 72,
+            decoration: BoxDecoration(
+              color: Colors.black12.withOpacity(0.08),
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+      );
     }
     if (_error != null) {
       return Scaffold(appBar: AppBar(title: const Text('Palette')), body: Center(child: Text(_error!)));

--- a/colrvia5-main/lib/services/analytics_service.dart
+++ b/colrvia5-main/lib/services/analytics_service.dart
@@ -43,6 +43,26 @@ class AnalyticsService {
     await _logEvent(name, params ?? {});
   }
 
+  Future<void> logAppOpen() => _analytics.logAppOpen();
+  Future<void> setUserId(String? uid) => _analytics.setUserId(id: uid);
+  Future<void> interviewStarted({String? mode}) =>
+      _logEvent('interview_started', {'mode': mode});
+  Future<void> interviewAnswerSet(String id) =>
+      _logEvent('interview_answer', {'id': id});
+  Future<void> interviewCompleted() =>
+      _logEvent('interview_completed', {});
+  Future<void> reviewConfirmed() =>
+      _logEvent('review_confirmed', {});
+  Future<void> paletteGenerated({String? brand}) =>
+      _logEvent('palette_generated', {'brand': brand});
+  Future<void> visualizerOpened() =>
+      _logEvent('visualizer_opened', {});
+  Future<void> visualizerStroke({required String role}) =>
+      _logEvent('viz_stroke', {'role': role});
+  Future<void> vizExport() => _logEvent('viz_export', {});
+  Future<void> talkStart() => _logEvent('talk_start', {});
+  Future<void> talkEnd() => _logEvent('talk_end', {});
+
   List<Map<String, dynamic>> get recentEvents =>
       List.unmodifiable(_recentEvents);
 

--- a/colrvia5-main/lib/services/crash_service.dart
+++ b/colrvia5-main/lib/services/crash_service.dart
@@ -1,0 +1,20 @@
+// lib/services/crash_service.dart
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+class CrashService {
+  CrashService._();
+  static final instance = CrashService._();
+  final _c = FirebaseCrashlytics.instance;
+
+  Future<void> setUser(String? uid) async {
+    if (uid != null) await _c.setUserIdentifier(uid);
+  }
+
+  Future<void> breadcrumb(String msg) async {
+    await _c.log(msg);
+  }
+
+  Future<void> recordError(Object e, StackTrace s, {bool fatal = false}) async {
+    await _c.recordError(e, s, fatal: fatal);
+  }
+}

--- a/colrvia5-main/lib/services/performance_service.dart
+++ b/colrvia5-main/lib/services/performance_service.dart
@@ -1,0 +1,14 @@
+// lib/services/performance_service.dart
+import 'package:firebase_performance/firebase_performance.dart';
+
+class Perf {
+  static Future<T> traceAsync<T>(String name, Future<T> Function() fn) async {
+    final t = FirebasePerformance.instance.newTrace(name);
+    await t.start();
+    try {
+      return await fn();
+    } finally {
+      await t.stop();
+    }
+  }
+}

--- a/colrvia5-main/lib/services/privacy_prefs.dart
+++ b/colrvia5-main/lib/services/privacy_prefs.dart
@@ -1,0 +1,18 @@
+// lib/services/privacy_prefs.dart
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+class PrivacyPrefs {
+  static const _kAnalytics = 'analytics_enabled';
+
+  static Future<bool> analyticsEnabled() async {
+    final sp = await SharedPreferences.getInstance();
+    return sp.getBool(_kAnalytics) ?? true;
+  }
+
+  static Future<void> setAnalytics(bool enabled) async {
+    final sp = await SharedPreferences.getInstance();
+    await sp.setBool(_kAnalytics, enabled);
+    await FirebaseAnalytics.instance.setAnalyticsCollectionEnabled(enabled);
+  }
+}

--- a/colrvia5-main/pubspec.yaml
+++ b/colrvia5-main/pubspec.yaml
@@ -28,12 +28,13 @@ dependencies:
   just_audio: ^0.10.4
   share_plus: ^11.1.0
   firebase_crashlytics: ^5.0.0
+  firebase_performance: ^0.10.0+18
   package_info_plus: ^8.0.0
   collection: ^1.18.0
   logging: ^1.2.0
   cupertino_icons: ^1.0.8
   google_fonts: ^6.1.0
-  shared_preferences: ^2.0.0
+  shared_preferences: ^2.3.2
   flutter_svg: ^2.0.0
   image: ^4.3.0
   path_provider: ^2.1.3
@@ -48,7 +49,7 @@ dependencies:
   uuid: ^4.4.0
   permission_handler: ^12.0.1
   http: ^1.1.0
-  intl: ^0.19.0
+  intl: ^0.20.2
   # UI helpers
   photo_view: ^0.15.0
   sqflite: ^2.4.2


### PR DESCRIPTION
## Summary
- add Firebase performance and shared preferences updates
- bootstrap Firebase analytics/performance and clamp text scaling
- replace alt visualizer with analytics events and export

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter format lib/main.dart ...` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b8c1fd26948322bd80a3ee7ccac439