### PR TITLE
feat: add interview home screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:color_canvas/screens/login_screen.dart';
 import 'package:color_canvas/screens/color_plan_detail_screen.dart';
 import 'package:color_canvas/screens/visualizer_screen.dart';
 import 'package:color_canvas/screens/color_plan_screen.dart';
+import 'package:color_canvas/screens/interview_home_screen.dart';
 import 'package:color_canvas/services/firebase_service.dart';
 import 'package:color_canvas/services/network_utils.dart';
 import 'package:color_canvas/utils/debug_logger.dart';
@@ -184,6 +185,7 @@ class MyApp extends StatelessWidget {
             '/auth': (context) => const AuthWrapper(),
             '/home': (context) => const HomeScreen(),
             '/login': (context) => const LoginScreen(),
+            '/interview/home': (context) => const InterviewHomeScreen(),
             '/colorPlan': (context) {
               final args =
                   ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;

--- a/lib/screens/interview_home_screen.dart
+++ b/lib/screens/interview_home_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+/// Interview entry screen that lets users choose between
+/// a voice or text based interview experience.
+///
+/// This screen matches the Colrvia peach–cream gradient style and
+/// uses Material 3 components for its calls to action.
+class InterviewHomeScreen extends StatelessWidget {
+  const InterviewHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      extendBodyBehindAppBar: true,
+      body: Stack(
+        children: [
+          // Background gradient with optional grain texture.
+          Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                colors: [Color(0xFFF2B897), Color(0xFFFFF8F2)],
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+              ),
+            ),
+          ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 32),
+                  Text(
+                    "Let’s design your perfect palette.",
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    "Answer a few questions — Via turns your style, lighting, and space into a color story you’ll love.",
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                  const Spacer(),
+                  FilledButton.icon(
+                    icon: const Icon(Icons.mic),
+                    label: const Text("Start with Via (Voice)"),
+                    onPressed: () {
+                      Navigator.pushNamed(context, '/interview/voice-setup');
+                    },
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(56),
+                      backgroundColor: const Color(0xFFF2B897),
+                      foregroundColor: Colors.black,
+                      textStyle: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: () {
+                      Navigator.pushNamed(context, '/interview/text');
+                    },
+                    style: OutlinedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(56),
+                    ),
+                    child: const Text("Type your answers"),
+                  ),
+                  const SizedBox(height: 24),
+                  ExpansionTile(
+                    title: const Text("How it works"),
+                    children: const [
+                      ListTile(title: Text("1. Chat for a few minutes.")),
+                      ListTile(
+                          title: Text(
+                              "2. We gather room, light, and style details.")),
+                      ListTile(
+                          title: Text(
+                              "3. Get your personalized palette plan.")),
+                      ListTile(
+                        title: Text(
+                          "Privacy & mic permissions",
+                          style: TextStyle(color: Colors.blue),
+                        ),
+                        onTap: () {
+                          // TODO: Implement privacy link
+                        },
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Center(
+                    child: Text(
+                      "~6–8 min • You can pause anytime • Switch modes later",
+                      style: Theme.of(context).textTheme.labelMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add interview home screen with gradient, CTAs, and explainer
- register `/interview/home` route

## Testing
- `dart format lib/screens/interview_home_screen.dart lib/main.dart` *(fails: command not found)*
- `flutter analyze lib/screens/interview_home_screen.dart lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fe3973308322a60e54bec31d11f4