### PR TITLE
Add voice interview screen and placeholder engine

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:color_canvas/screens/visualizer_screen.dart';
 import 'package:color_canvas/screens/color_plan_screen.dart';
 import 'package:color_canvas/screens/interview_home_screen.dart';
 import 'package:color_canvas/screens/interview_voice_setup_screen.dart';
+import 'package:color_canvas/screens/interview_voice_screen.dart';
 import 'package:color_canvas/services/firebase_service.dart';
 import 'package:color_canvas/services/network_utils.dart';
 import 'package:color_canvas/utils/debug_logger.dart';
@@ -188,6 +189,7 @@ class MyApp extends StatelessWidget {
             '/login': (context) => const LoginScreen(),
             '/interview/home': (context) => const InterviewHomeScreen(),
             '/interview/voice-setup': (context) => const InterviewVoiceSetupScreen(),
+            '/interview/voice': (context) => const InterviewVoiceScreen(),
             '/colorPlan': (context) {
               final args =
                   ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;

--- a/lib/screens/interview_voice_screen.dart
+++ b/lib/screens/interview_voice_screen.dart
@@ -1,0 +1,128 @@
+// lib/screens/interview_voice_screen.dart
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:color_canvas/services/interview_voice_engine.dart';
+import 'package:color_canvas/widgets/via_orb.dart';
+
+class InterviewVoiceScreen extends StatefulWidget {
+  const InterviewVoiceScreen({super.key});
+
+  @override
+  State<InterviewVoiceScreen> createState() => _InterviewVoiceScreenState();
+}
+
+class _InterviewVoiceScreenState extends State<InterviewVoiceScreen> {
+  final InterviewEngine _engine = InterviewEngine();
+  StreamSubscription<String?>? _subscription;
+  String? liveTranscript;
+
+  String get currentPrompt => _engine.currentPrompt;
+  bool get isListening => _engine.isListening;
+
+  @override
+  void initState() {
+    super.initState();
+    _engine.startVoiceMode();
+    _subscription = _engine.liveTranscriptStream.listen((text) {
+      setState(() => liveTranscript = text);
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _engine.endSession();
+    super.dispose();
+  }
+
+  void pauseInterview() {
+    _engine.pause();
+    setState(() {});
+  }
+
+  Future<void> showExitDialog(BuildContext context) async {
+    final shouldExit = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Exit Interview?'),
+        content: const Text('Your progress will be saved.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Exit'),
+          ),
+        ],
+      ),
+    );
+    if (shouldExit == true && mounted) {
+      Navigator.of(context).maybePop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        title: const Text('Via Interview'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => showExitDialog(context),
+          )
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            Text(
+              currentPrompt,
+              style: Theme.of(context).textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: Center(child: ViaOrb(isListening: isListening)),
+            ),
+            const SizedBox(height: 24),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                liveTranscript ?? 'Listening...',
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton.icon(
+                  icon: const Icon(Icons.pause),
+                  label: const Text('Pause'),
+                  onPressed: pauseInterview,
+                ),
+                OutlinedButton(
+                  onPressed: () {
+                    Navigator.pushReplacementNamed(context, '/interview/text');
+                  },
+                  child: const Text('Switch to typing'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/interview_voice_engine.dart
+++ b/lib/services/interview_voice_engine.dart
@@ -1,0 +1,43 @@
+// lib/services/interview_voice_engine.dart
+import 'dart:async';
+
+/// Placeholder voice interview engine that exposes a live transcript stream.
+class InterviewEngine {
+  InterviewEngine._internal();
+  static final InterviewEngine _instance = InterviewEngine._internal();
+  factory InterviewEngine() => _instance;
+
+  final _controller = StreamController<String?>.broadcast();
+  Stream<String?> get liveTranscriptStream => _controller.stream;
+
+  bool _isListening = false;
+  bool get isListening => _isListening;
+
+  String currentPrompt = 'Tell me about your space';
+
+  Timer? _timer;
+
+  /// Start listening for voice input.
+  void startVoiceMode() {
+    _isListening = true;
+    _timer?.cancel();
+    // Simulate transcript updates for demo purposes.
+    _timer = Timer.periodic(const Duration(seconds: 3), (t) {
+      _controller.add('Sample response ${t.tick}');
+    });
+  }
+
+  /// Pause voice capture.
+  void pause() {
+    _isListening = false;
+    _timer?.cancel();
+    _controller.add(null);
+  }
+
+  /// End the interview session and clean up.
+  void endSession() {
+    _timer?.cancel();
+    _isListening = false;
+    _controller.add(null);
+  }
+}

--- a/lib/widgets/via_orb.dart
+++ b/lib/widgets/via_orb.dart
@@ -1,0 +1,64 @@
+// lib/widgets/via_orb.dart
+import 'package:flutter/material.dart';
+
+/// Simple animated orb that pulses while listening.
+class ViaOrb extends StatefulWidget {
+  final bool isListening;
+  const ViaOrb({super.key, required this.isListening});
+
+  @override
+  State<ViaOrb> createState() => _ViaOrbState();
+}
+
+class _ViaOrbState extends State<ViaOrb> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    if (widget.isListening) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(ViaOrb oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isListening && !_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    } else if (!widget.isListening && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: Tween(begin: 1.0, end: 1.2)
+          .animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut)),
+      child: Container(
+        width: 120,
+        height: 120,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: RadialGradient(
+            colors: [
+              Theme.of(context).colorScheme.primary.withOpacity(0.8),
+              Theme.of(context).colorScheme.primary.withOpacity(0.3),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add voice-based interview screen with animated orb, live transcript, and exit/pause controls
- Introduce placeholder InterviewEngine and ViaOrb widget to drive voice UI
- Register `/interview/voice` route in the app

## Testing
- `flutter format lib/services/interview_voice_engine.dart lib/widgets/via_orb.dart lib/screens/interview_voice_screen.dart lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b900c6322c8322b3111be48acfa229