### PR TITLE
Add text-based interview screen with chat bubbles

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:color_canvas/screens/color_plan_screen.dart';
 import 'package:color_canvas/screens/interview_home_screen.dart';
 import 'package:color_canvas/screens/interview_voice_setup_screen.dart';
 import 'package:color_canvas/screens/interview_voice_screen.dart';
+import 'package:color_canvas/screens/interview_text_screen.dart';
 import 'package:color_canvas/services/firebase_service.dart';
 import 'package:color_canvas/services/network_utils.dart';
 import 'package:color_canvas/utils/debug_logger.dart';
@@ -190,6 +191,7 @@ class MyApp extends StatelessWidget {
             '/interview/home': (context) => const InterviewHomeScreen(),
             '/interview/voice-setup': (context) => const InterviewVoiceSetupScreen(),
             '/interview/voice': (context) => const InterviewVoiceScreen(),
+            '/interview/text': (context) => const InterviewTextScreen(),
             '/colorPlan': (context) {
               final args =
                   ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;

--- a/lib/models/interview_turn.dart
+++ b/lib/models/interview_turn.dart
@@ -1,0 +1,7 @@
+// lib/models/interview_turn.dart
+class InterviewTurn {
+  final String text;
+  final bool isUser;
+
+  const InterviewTurn({required this.text, required this.isUser});
+}

--- a/lib/screens/interview_text_screen.dart
+++ b/lib/screens/interview_text_screen.dart
@@ -1,0 +1,153 @@
+// lib/screens/interview_text_screen.dart
+import 'package:flutter/material.dart';
+import 'package:color_canvas/services/interview_voice_engine.dart';
+import 'package:color_canvas/models/interview_turn.dart';
+import 'package:color_canvas/widgets/user_bubble.dart';
+import 'package:color_canvas/widgets/via_bubble.dart';
+
+class InterviewTextScreen extends StatefulWidget {
+  const InterviewTextScreen({super.key});
+
+  @override
+  State<InterviewTextScreen> createState() => _InterviewTextScreenState();
+}
+
+class _InterviewTextScreenState extends State<InterviewTextScreen> {
+  final _controller = TextEditingController();
+  final _scrollController = ScrollController();
+  List<InterviewTurn> turns = [];
+
+  @override
+  void initState() {
+    super.initState();
+    final engine = InterviewEngine();
+    engine.startTextMode();
+    turns = engine.initialTurns;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    InterviewEngine().endSession();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void submitAnswer() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+
+    setState(() {
+      turns.add(InterviewTurn(text: text, isUser: true));
+      _controller.clear();
+    });
+    _scrollToBottom();
+
+    InterviewEngine().submitTextAnswer(text).then((viaResponse) {
+      if (!mounted) return;
+      setState(() {
+        turns.add(InterviewTurn(text: viaResponse, isUser: false));
+      });
+      _scrollToBottom();
+    });
+  }
+
+  Future<void> showExitDialog(BuildContext context) async {
+    final shouldExit = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Exit Interview?'),
+        content: const Text('Your progress will be saved.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Exit'),
+          ),
+        ],
+      ),
+    );
+    if (shouldExit == true && mounted) {
+      Navigator.of(context).maybePop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Via Interview'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => showExitDialog(context),
+          )
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: turns.isEmpty
+                ? const Center(child: Text('No questions loaded'))
+                : ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.all(16),
+                    itemCount: turns.length,
+                    itemBuilder: (context, index) {
+                      final turn = turns[index];
+                      return turn.isUser
+                          ? UserBubble(text: turn.text)
+                          : ViaBubble(text: turn.text);
+                    },
+                  ),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    textInputAction: TextInputAction.send,
+                    onSubmitted: (_) => submitAnswer(),
+                    decoration: InputDecoration(
+                      hintText: 'Type your answer…',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: submitAnswer,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/interview_voice_engine.dart
+++ b/lib/services/interview_voice_engine.dart
@@ -1,7 +1,9 @@
 // lib/services/interview_voice_engine.dart
 import 'dart:async';
 
-/// Placeholder voice interview engine that exposes a live transcript stream.
+import 'package:color_canvas/models/interview_turn.dart';
+
+/// Placeholder interview engine supporting both voice and text modes.
 class InterviewEngine {
   InterviewEngine._internal();
   static final InterviewEngine _instance = InterviewEngine._internal();
@@ -13,7 +15,14 @@ class InterviewEngine {
   bool _isListening = false;
   bool get isListening => _isListening;
 
+  final List<String> _prompts = [
+    'Tell me about your space',
+    'What mood are you hoping to create?',
+    'Any colors you love or hate?'
+  ];
+
   String currentPrompt = 'Tell me about your space';
+  int _promptIndex = 0;
 
   Timer? _timer;
 
@@ -25,6 +34,27 @@ class InterviewEngine {
     _timer = Timer.periodic(const Duration(seconds: 3), (t) {
       _controller.add('Sample response ${t.tick}');
     });
+  }
+
+  /// Initialize text interview mode.
+  void startTextMode() {
+    _promptIndex = 0;
+    currentPrompt = _prompts[_promptIndex];
+  }
+
+  /// Initial turns to seed the chat UI.
+  List<InterviewTurn> get initialTurns =>
+      [InterviewTurn(text: currentPrompt, isUser: false)];
+
+  /// Submit a user answer and receive Via's next prompt.
+  Future<String> submitTextAnswer(String answer) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    _promptIndex++;
+    if (_promptIndex < _prompts.length) {
+      currentPrompt = _prompts[_promptIndex];
+      return currentPrompt;
+    }
+    return 'Thanks for sharing!';
   }
 
   /// Pause voice capture.

--- a/lib/widgets/user_bubble.dart
+++ b/lib/widgets/user_bubble.dart
@@ -1,0 +1,25 @@
+// lib/widgets/user_bubble.dart
+import 'package:flutter/material.dart';
+
+class UserBubble extends StatelessWidget {
+  final String text;
+  const UserBubble({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = Theme.of(context).colorScheme.primaryContainer;
+    final fg = Theme.of(context).colorScheme.onPrimaryContainer;
+    return Align(
+      alignment: Alignment.centerRight,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Text(text, style: TextStyle(color: fg)),
+      ),
+    );
+  }
+}

--- a/lib/widgets/via_bubble.dart
+++ b/lib/widgets/via_bubble.dart
@@ -1,0 +1,25 @@
+// lib/widgets/via_bubble.dart
+import 'package:flutter/material.dart';
+
+class ViaBubble extends StatelessWidget {
+  final String text;
+  const ViaBubble({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = Theme.of(context).colorScheme.surfaceContainerHighest;
+    final fg = Theme.of(context).colorScheme.onSurface;
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Text(text, style: TextStyle(color: fg)),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement chat-style Via interview screen with user input and auto-scroll
- add bubble widgets for user and Via messages
- extend interview engine with text mode prompts and hook up route

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b902eb97f083229e3243b85ad746f1