### PR TITLE
Add interview session persistence to Firestore

### DIFF
--- a/lib/models/interview_session.dart
+++ b/lib/models/interview_session.dart
@@ -1,0 +1,39 @@
+// lib/models/interview_session.dart
+import 'interview_turn.dart';
+
+class InterviewSession {
+  final String id;
+  final String userId;
+  final List<InterviewTurn> turns;
+  final DateTime startedAt;
+  final DateTime updatedAt;
+
+  InterviewSession({
+    required this.id,
+    required this.userId,
+    required this.turns,
+    required this.startedAt,
+    required this.updatedAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'userId': userId,
+        'turns': turns.map((t) => t.toJson()).toList(),
+        'startedAt': startedAt.toIso8601String(),
+        'updatedAt': updatedAt.toIso8601String(),
+      };
+
+  factory InterviewSession.fromJson(Map<String, dynamic> json) {
+    return InterviewSession(
+      id: json['id'],
+      userId: json['userId'],
+      turns: (json['turns'] as List)
+          .map((t) => InterviewTurn.fromJson(t))
+          .toList(),
+      startedAt: DateTime.parse(json['startedAt']),
+      updatedAt: DateTime.parse(json['updatedAt']),
+    );
+  }
+}
+

--- a/lib/models/interview_turn.dart
+++ b/lib/models/interview_turn.dart
@@ -3,4 +3,16 @@ class InterviewTurn {
   final String text;
   final bool isUser;
   InterviewTurn({required this.text, required this.isUser});
+
+  Map<String, dynamic> toJson() => {
+        'text': text,
+        'isUser': isUser,
+      };
+
+  factory InterviewTurn.fromJson(Map<String, dynamic> json) {
+    return InterviewTurn(
+      text: json['text'],
+      isUser: json['isUser'] ?? false,
+    );
+  }
 }

--- a/lib/services/interview_session_service.dart
+++ b/lib/services/interview_session_service.dart
@@ -1,0 +1,31 @@
+// lib/services/interview_session_service.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/interview_session.dart';
+import '../models/interview_turn.dart';
+
+class InterviewSessionService {
+  InterviewSession createSession(List<InterviewTurn> turns) {
+    final doc =
+        FirebaseFirestore.instance.collection('interviewSessions').doc();
+    final userId = FirebaseAuth.instance.currentUser?.uid ?? '';
+    final now = DateTime.now();
+
+    return InterviewSession(
+      id: doc.id,
+      userId: userId,
+      turns: turns,
+      startedAt: now,
+      updatedAt: now,
+    );
+  }
+
+  Future<void> saveSession(InterviewSession session) async {
+    await FirebaseFirestore.instance
+        .collection('interviewSessions')
+        .doc(session.id)
+        .set(session.toJson());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `InterviewSession` model for storing turns with timestamps
- extend `InterviewTurn` with JSON serialization
- create `InterviewSessionService` to create and save sessions in Firestore

## Testing
- `flutter format lib/models/interview_turn.dart lib/models/interview_session.dart lib/services/interview_session_service.dart` (command not found)
- `flutter test` (command not found)
- `dart test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b90a57f38c8322aca67fe6b2a5688a