### PR TITLE
Refactor interview screens to shared engine and persist sessions

### DIFF
--- a/lib/screens/interview_review_screen.dart
+++ b/lib/screens/interview_review_screen.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:color_canvas/services/journey/journey_service.dart';
 import 'package:color_canvas/services/interview_engine.dart';
+import 'package:color_canvas/services/interview_shared_engine.dart' as shared;
 import 'package:color_canvas/widgets/photo_picker_inline.dart';
 import 'package:color_canvas/services/palette_service.dart';
 import 'package:color_canvas/screens/palette_reveal_screen.dart';
@@ -52,6 +53,7 @@ class _InterviewReviewScreenState extends State<InterviewReviewScreen> {
     final answers = Map<String, dynamic>.from(_answers);
 
     setState(() {}); // optional: show loading state on button
+    await shared.InterviewEngine().saveSessionToFirestore();
     await PaletteService.instance.generateFromAnswers(answers);
 
     await JourneyService.instance.completeCurrentStep();

--- a/lib/screens/interview_voice_screen.dart
+++ b/lib/screens/interview_voice_screen.dart
@@ -1,7 +1,7 @@
 // lib/screens/interview_voice_screen.dart
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:color_canvas/services/interview_voice_engine.dart';
+import 'package:color_canvas/services/interview_shared_engine.dart';
 import 'package:color_canvas/widgets/via_orb.dart';
 
 class InterviewVoiceScreen extends StatefulWidget {
@@ -12,7 +12,7 @@ class InterviewVoiceScreen extends StatefulWidget {
 }
 
 class _InterviewVoiceScreenState extends State<InterviewVoiceScreen> {
-  final InterviewVoiceEngine _engine = InterviewVoiceEngine();
+  final InterviewEngine _engine = InterviewEngine();
   StreamSubscription<String?>? _subscription;
   String? liveTranscript;
 


### PR DESCRIPTION
## Summary
- Refactor text and voice interview screens to use new `InterviewEngine` singleton
- Add Firestore persistence for interview sessions via `saveSessionToFirestore`
- Invoke session persistence from the review screen's "Looks good" flow

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90fccefdc83228ba6af060aad937c