### PR TITLE
Add reusable ColorSwatchCard and show pairings in paint detail

### DIFF
--- a/lib/widgets/color_swatch_card.dart
+++ b/lib/widgets/color_swatch_card.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:color_canvas/firestore/firestore_data_schema.dart';
+import 'package:color_canvas/utils/color_utils.dart';
+
+class ColorSwatchCard extends StatelessWidget {
+  final Paint paint;
+  final double size;
+  final VoidCallback? onTap;
+
+  const ColorSwatchCard({
+    super.key,
+    required this.paint,
+    this.size = 72,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = ColorUtils.getPaintColor(paint.hex);
+    final textColor = ThemeData.estimateBrightnessForColor(color) == Brightness.dark
+        ? Colors.white
+        : Colors.black;
+
+    final swatch = Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.2)),
+      ),
+      alignment: Alignment.bottomCenter,
+      child: Padding(
+        padding: const EdgeInsets.all(6),
+        child: Text(
+          paint.code,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: textColor,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+
+    return Semantics(
+      label: '${paint.name}, ${paint.code}',
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            swatch,
+            const SizedBox(height: 8),
+            SizedBox(
+              width: size,
+              child: Text(
+                paint.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `ColorSwatchCard` widget to render a rounded color swatch with code overlay and name label
- replace placeholder Pairings tab with list of tappable `ColorSwatchCard`s that load companion paints

## Testing
- `dart format lib/widgets/color_swatch_card.dart lib/screens/paint_detail_screen.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb301ef9fc83228bc9035b760a1032