### PR TITLE
feat: add semantic labels to icons

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -315,15 +315,13 @@ class _AccountHeaderDelegate extends SliverPersistentHeaderDelegate {
                     color: creamWhite.withValues(alpha: 0.2),
                   ),
                 ),
-                child: Tooltip(
-                  message: 'Settings',
-                  child: ColrViaIconButton(
-                    icon: Icons.settings_rounded,
-                    color: creamWhite,
-                    onPressed: () => Navigator.of(context).push(
-                      MaterialPageRoute(builder: (_) => const SettingsScreen()),
-                    ),
+                child: ColrViaIconButton(
+                  icon: Icons.settings_rounded,
+                  color: creamWhite,
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const SettingsScreen()),
                   ),
+                  semanticLabel: 'Settings',
                 ),
               ),
             ],

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -41,13 +41,11 @@ class _ExploreScreenState extends State<ExploreScreen> {
       appBar: AppBar(
         title: const Text('Explore Color Stories'),
         actions: [
-          Tooltip(
-            message: 'Toggle loading',
-            child: app.ColrViaIconButton(
-              icon: Icons.refresh,
-              color: Theme.of(context).colorScheme.onSurface,
-              onPressed: () => setState(() => _isLoading = !_isLoading),
-            ),
+          app.ColrViaIconButton(
+            icon: Icons.refresh,
+            color: Theme.of(context).colorScheme.onSurface,
+            onPressed: () => setState(() => _isLoading = !_isLoading),
+            semanticLabel: 'Toggle loading',
           )
         ],
       ),
@@ -69,6 +67,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
                           _searchController.clear();
                           _onSearchChanged('');
                         },
+                        semanticLabel: 'Clear search',
                       )
                     : null,
                 border:
@@ -471,6 +470,7 @@ class _CardSkeleton extends StatelessWidget {
                       icon: Icons.close,
                       color: Theme.of(context).colorScheme.onSurface,
                       onPressed: () => Navigator.pop(context),
+                      semanticLabel: 'Close',
                     ),
                   ],
                 ),
@@ -493,6 +493,7 @@ class _CardSkeleton extends StatelessWidget {
                               _searchController.clear();
                               _onSearchChanged('');
                             },
+                            semanticLabel: 'Clear search',
                           )
                         : null,
                     border: OutlineInputBorder(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -521,10 +521,15 @@ class _ViaBubbleState extends State<ViaBubble> with SingleTickerProviderStateMix
       ),
     );
 
-    return Tooltip(
-      message: widget.tooltip ?? 'Ask Via',
-      preferBelow: false,
-      child: bubble,
+    final label = widget.tooltip ?? 'Ask Via';
+    return Semantics(
+      button: true,
+      label: label,
+      child: Tooltip(
+        message: label,
+        preferBelow: false,
+        child: bubble,
+      ),
     );
   }
 }

--- a/lib/screens/paint_detail_screen.dart
+++ b/lib/screens/paint_detail_screen.dart
@@ -153,6 +153,7 @@ class _PaintDetailScreenState extends State<PaintDetailScreen> {
                     icon: Icons.arrow_back,
                     color: fg,
                     onPressed: () => Navigator.of(context).maybePop(),
+                    semanticLabel: 'Back',
                   ),
                 ),
                 actions: [
@@ -162,6 +163,7 @@ class _PaintDetailScreenState extends State<PaintDetailScreen> {
                       icon: Icons.add,
                       color: fg,
                       onPressed: _showAddMenu,
+                      semanticLabel: 'More options',
                     ),
                   ),
                   Padding(
@@ -171,6 +173,8 @@ class _PaintDetailScreenState extends State<PaintDetailScreen> {
                       color: fg,
                       busy: _favBusy,
                       onPressed: _toggleFavorite,
+                      semanticLabel:
+                          _isFavorite ? 'Remove from favorites' : 'Save to favorites',
                     ),
                   ),
                 ],

--- a/lib/screens/photo_library_screen.dart
+++ b/lib/screens/photo_library_screen.dart
@@ -86,16 +86,15 @@ class _PhotoLibraryScreenState extends State<PhotoLibraryScreen> {
                 icon: Icons.arrow_back_ios_new,
                 color: creamWhite,
                 onPressed: () => Navigator.pop(context),
+                semanticLabel: 'Back',
               ),
               actions: [
                 if (_photos.isNotEmpty)
-                  Tooltip(
-                    message: 'Clear All Photos',
-                    child: ColrViaIconButton(
-                      icon: Icons.delete_sweep,
-                      color: creamWhite,
-                      onPressed: _showClearAllDialog,
-                    ),
+                  ColrViaIconButton(
+                    icon: Icons.delete_sweep,
+                    color: creamWhite,
+                    onPressed: _showClearAllDialog,
+                    semanticLabel: 'Clear all photos',
                   ),
               ],
             ),

--- a/lib/screens/project_overview_screen.dart
+++ b/lib/screens/project_overview_screen.dart
@@ -70,6 +70,7 @@ class ProjectOverviewScreen extends StatelessWidget {
                         AnalyticsService.instance.ctaCompareClicked('project_overview');
                       }
                     : null,
+                semanticLabel: 'Compare colors',
               ),
             ]),
           ),

--- a/lib/screens/projects_screen.dart
+++ b/lib/screens/projects_screen.dart
@@ -310,21 +310,19 @@ class _ProjectsScreenState extends State<ProjectsScreen> {
         title: const m.Text('My Library'),
         actions: [
           if (_hasPermissionError)
-            Tooltip(
-              message: 'Permission Issues',
-              child: app.ColrViaIconButton(
-                icon: Icons.warning_amber_outlined,
-                color: Colors.orange,
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: m.Text(
-                          'Some data may not be available due to permission issues. Try signing out and back in.'),
-                      duration: Duration(seconds: 4),
-                    ),
-                  );
-                },
-              ),
+            app.ColrViaIconButton(
+              icon: Icons.warning_amber_outlined,
+              color: Colors.orange,
+              onPressed: () {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: m.Text(
+                        'Some data may not be available due to permission issues. Try signing out and back in.'),
+                    duration: Duration(seconds: 4),
+                  ),
+                );
+              },
+              semanticLabel: 'Permission issues',
             ),
         ],
       ),
@@ -1075,6 +1073,7 @@ class _EditTagsDialogState extends State<EditTagsDialog> {
                   icon: Icons.add,
                   color: Theme.of(context).colorScheme.onSurface,
                   onPressed: _addCustomTag,
+                  semanticLabel: 'Add tag',
                 ),
               ],
             ),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -735,6 +735,7 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
                     });
                     _searchFocusNode.unfocus();
                   },
+                  semanticLabel: 'Clear search',
                 )
               : null,
         ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -468,6 +468,7 @@ class _SettingsScreenState extends State<SettingsScreen>
         icon: Icons.arrow_back_ios_new,
         color: Colors.white,
         onPressed: () => Navigator.pop(context),
+        semanticLabel: 'Back',
       ),
     );
   }

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -187,6 +187,7 @@ class _VisualizerScreenState extends State<VisualizerScreen>
                   _navigateToMode(VisualizerMode.welcome);
                 }
               },
+              semanticLabel: 'Back',
             )
           : null,
       centerTitle: true,
@@ -1767,6 +1768,7 @@ class _VisualizerScreenState extends State<VisualizerScreen>
                       icon: Icons.close,
                       color: Colors.white,
                       onPressed: () => Navigator.pop(context),
+                      semanticLabel: 'Close',
                     ),
                   ],
                 ),

--- a/lib/widgets/colr_via_icon_button.dart
+++ b/lib/widgets/colr_via_icon_button.dart
@@ -15,6 +15,7 @@ class ColrViaIconButton extends StatelessWidget {
   final double borderRadius;
   final double borderWidth;
   final ColrViaIconButtonStyle style;
+  final String? semanticLabel;
 
   const ColrViaIconButton({
     super.key,
@@ -28,6 +29,7 @@ class ColrViaIconButton extends StatelessWidget {
     this.borderRadius = 12,
     this.borderWidth = 1.2,
     this.style = ColrViaIconButtonStyle.outline,
+    this.semanticLabel,
   });
 
   @override
@@ -42,7 +44,7 @@ class ColrViaIconButton extends StatelessWidget {
                 : Colors.black)
             : color);
 
-    return Material(
+    Widget button = Material(
       color: bg,
       shape: RoundedRectangleBorder(
         borderRadius: r,
@@ -78,6 +80,19 @@ class ColrViaIconButton extends StatelessWidget {
           ),
         ),
       ),
+    );
+
+    if (semanticLabel != null) {
+      button = Tooltip(
+        message: semanticLabel!,
+        child: button,
+      );
+    }
+
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      child: button,
     );
   }
 }

--- a/lib/widgets/via_overlay.dart
+++ b/lib/widgets/via_overlay.dart
@@ -313,6 +313,7 @@ class _OverlayHeader extends StatelessWidget {
           _HeaderSquareIcon(
             icon: isExpanded ? Icons.close_fullscreen_rounded : Icons.open_in_full_rounded,
             onTap: isExpanded ? onCollapse : onExpand,
+            semanticLabel: isExpanded ? 'Collapse' : 'Expand',
           ),
         ],
       ),
@@ -323,11 +324,12 @@ class _OverlayHeader extends StatelessWidget {
 class _HeaderSquareIcon extends StatelessWidget {
   final IconData icon;
   final VoidCallback onTap;
-  const _HeaderSquareIcon({required this.icon, required this.onTap});
+  final String? semanticLabel;
+  const _HeaderSquareIcon({required this.icon, required this.onTap, this.semanticLabel});
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
+    Widget btn = InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(10),
       child: Container(
@@ -341,6 +343,13 @@ class _HeaderSquareIcon extends StatelessWidget {
         child: Icon(icon, size: 18, color: Colors.white),
       ),
     );
+    if (semanticLabel != null) {
+      btn = Tooltip(message: semanticLabel!, child: btn);
+      btn = Semantics(button: true, label: semanticLabel, child: btn);
+    } else {
+      btn = Semantics(button: true, child: btn);
+    }
+    return btn;
   }
 }
 


### PR DESCRIPTION
## Summary
- add optional semanticLabel support to ColrViaIconButton
- label icon-only controls on screens like Paint Detail, Explore, Photo Library, Search, Settings, Projects, Dashboard, and Visualizer
- expose semantics for Via bubble and overlay header

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter format lib/widgets/colr_via_icon_button.dart lib/screens/paint_detail_screen.dart lib/screens/project_overview_screen.dart lib/screens/explore_screen.dart lib/screens/photo_library_screen.dart lib/screens/search_screen.dart lib/screens/settings_screen.dart lib/screens/projects_screen.dart lib/screens/dashboard_screen.dart lib/screens/visualizer_screen.dart lib/screens/home_screen.dart lib/widgets/via_overlay.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb35d2358483228dd26411a145a9c5