### PR TITLE
feat: add riverpod for auth state management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_performance/firebase_performance.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:color_canvas/screens/compare_screen.dart';
 // REGION: CODEX-ADD compare-colors-import
 // END REGION: CODEX-ADD compare-colors-import
@@ -64,7 +65,7 @@ Future<void> main() async {
     isFirebaseInitialized = true;
 
     Debug.info('App', 'main', 'Running app');
-    runApp(const MyApp()); // <- same zone as ensureInitialized()
+    runApp(const ProviderScope(child: MyApp())); // <- same zone as ensureInitialized()
 
     // Non-critical setup after first frame
     WidgetsBinding.instance.addPostFrameCallback((_) async {

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:color_canvas/services/firebase_service.dart';
+
+final authProvider = StreamProvider<User?>((ref) {
+  return FirebaseService.authStateChanges;
+});

--- a/lib/screens/auth_wrapper.dart
+++ b/lib/screens/auth_wrapper.dart
@@ -1,36 +1,30 @@
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:color_canvas/services/firebase_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:color_canvas/providers.dart';
 import 'package:color_canvas/screens/home_screen.dart';
 import 'package:color_canvas/screens/login_screen.dart';
 
-class AuthWrapper extends StatelessWidget {
+class AuthWrapper extends ConsumerWidget {
   const AuthWrapper({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<User?>(
-      stream: FirebaseService.authStateChanges,
-      builder: (context, snapshot) {
-        // Show loading indicator while checking auth state
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Scaffold(
-            backgroundColor: Colors.white,
-            body: Center(
-              child: CircularProgressIndicator(),
-            ),
-          );
-        }
-
-        // Show appropriate screen based on auth state
-        if (snapshot.hasData && snapshot.data != null) {
-          // User is signed in
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authProvider);
+    return authState.when(
+      data: (user) {
+        if (user != null) {
           return const HomeScreen();
         } else {
-          // User is not signed in
           return const LoginScreen();
         }
       },
+      loading: () => const Scaffold(
+        backgroundColor: Colors.white,
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, stack) => const LoginScreen(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   speech_to_text: ^7.3.0
   flutter_tts: ^4.2.3
   flutter_webrtc: ^1.1.0
+  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add flutter_riverpod dependency
- expose auth state via StreamProvider
- wrap app with ProviderScope and consume auth provider in auth wrapper

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ea722908322a7ebc8c22b950c20