### PR TITLE
feat: add user palette providers

### DIFF
--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -1,7 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:color_canvas/services/firebase_service.dart';
+import 'package:color_canvas/firestore/firestore_data_schema.dart';
 
 final authProvider = StreamProvider<User?>((ref) {
   return FirebaseService.authStateChanges;
+});
+
+final userPalettesProvider = FutureProvider<List<UserPalette>>((ref) async {
+  final user = FirebaseService.currentUser;
+  if (user == null) return [];
+  return FirebaseService.getUserPalettes(user.uid);
+});
+
+final favoriteColorsProvider =
+    FutureProvider<List<Paint>>((ref) async {
+  final user = FirebaseService.currentUser;
+  if (user == null) return [];
+  return FirebaseService.getUserFavoriteColors(user.uid);
 });


### PR DESCRIPTION
## Summary
- add future providers for user palettes and favorite colors
- refactor projects screen to consume userPalettesProvider instead of manual Firebase calls

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb41dc67c4832288daca93eb9b759e