### PR TITLE
feat: visualize palettes from detail screens

### DIFF
--- a/lib/screens/color_plan_detail_screen.dart
+++ b/lib/screens/color_plan_detail_screen.dart
@@ -420,6 +420,7 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
       MaterialPageRoute(
         builder: (_) => VisualizerScreen(
           storyId: story.id,
+          initialPalette: story.palette.map((p) => p.hex).toList(),
         ),
         settings: RouteSettings(
           name: '/visualizer',
@@ -678,7 +679,7 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                       const SizedBox(height: 20),
                       FilledButton.tonal(
                         onPressed: () => _applyPlanToVisualizer(plan),
-                        child: const Text('Apply to Visualizer (preview)'),
+                        child: const Text('Visualize Palette (preview)'),
                       ),
                     ],
                   ),
@@ -1499,7 +1500,7 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                           child: FilledButton.icon(
                             onPressed: () => _applyStoryToVisualizer(story),
                             icon: const Icon(Icons.auto_fix_high),
-                            label: const Text('Apply to Visualizer'),
+                            label: const Text('Visualize Palette'),
                             style: FilledButton.styleFrom(
                               padding: const EdgeInsets.symmetric(vertical: 16),
                             ),
@@ -1552,6 +1553,8 @@ class _ColorPlanDetailScreenState extends State<ColorPlanDetailScreen> {
                               MaterialPageRoute(
                                 builder: (_) => VisualizerScreen(
                                   storyId: widget.storyId,
+                                  initialPalette:
+                                      story.palette.map((p) => p.hex).toList(),
                                 ),
                               ),
                             );

--- a/lib/screens/palette_detail_screen.dart
+++ b/lib/screens/palette_detail_screen.dart
@@ -14,6 +14,7 @@ import 'package:color_canvas/services/analytics_service.dart';
 import 'package:color_canvas/services/project_service.dart';
 import 'package:color_canvas/services/auth_guard.dart';
 import 'package:color_canvas/widgets/paint_action_sheet.dart';
+import 'visualizer_screen.dart';
 
 class PaletteDetailScreen extends StatefulWidget {
   final UserPalette palette;
@@ -101,12 +102,26 @@ class _PaletteDetailScreenState extends State<PaletteDetailScreen> {
         subject: '${widget.palette.name} - Color Palette');
   }
 
+  void _openVisualizer() {
+    final hexCodes = widget.palette.colors.map((c) => c.hex).toList();
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => VisualizerScreen(initialPalette: hexCodes),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Palette Details'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.auto_fix_high),
+            onPressed: _openVisualizer,
+            tooltip: 'Visualize',
+          ),
           PopupMenuButton(
             onSelected: (value) async {
               switch (value) {
@@ -124,6 +139,9 @@ class _PaletteDetailScreenState extends State<PaletteDetailScreen> {
                       widget.palette.colors.map((c) => c.paintId).toList();
                   if (!mounted) return;
                   _openInRoller(ids);
+                  break;
+                case 'visualize':
+                  _openVisualizer();
                   break;
                 case 'delete':
                   final confirmed = await showDialog<bool>(
@@ -209,6 +227,16 @@ class _PaletteDetailScreenState extends State<PaletteDetailScreen> {
                     Icon(Icons.casino, size: 16),
                     SizedBox(width: 8),
                     Text('Open in Roller')
+                  ],
+                ),
+              ),
+              const PopupMenuItem(
+                value: 'visualize',
+                child: Row(
+                  children: [
+                    Icon(Icons.auto_fix_high, size: 16),
+                    SizedBox(width: 8),
+                    Text('Visualize'),
                   ],
                 ),
               ),

--- a/lib/screens/projects_screen.dart
+++ b/lib/screens/projects_screen.dart
@@ -516,6 +516,7 @@ class _PalettesSection extends ConsumerWidget {
               onDelete: () => _deletePalette(context, palette),
               onEdit: () => _editPaletteTags(context, palette),
               onOpenInRoller: () => _openPaletteInRoller(context, palette),
+              onVisualize: () => _openPaletteInVisualizer(context, palette),
             );
           },
         );
@@ -540,6 +541,20 @@ class _PalettesSection extends ConsumerWidget {
     nav.pushReplacement(
       MaterialPageRoute(
         builder: (_) => roller.RollerScreen(seedPaletteId: palette.id),
+      ),
+    );
+  }
+
+  Future<void> _openPaletteInVisualizer(
+      BuildContext context, UserPalette palette) async {
+    final nav = Navigator.of(context);
+    await viz.loadLibrary();
+    if (!nav.mounted) return;
+    nav.push(
+      MaterialPageRoute(
+        builder: (_) => viz.VisualizerScreen(
+          initialPalette: palette.colors.map((c) => c.hex).toList(),
+        ),
       ),
     );
   }
@@ -615,6 +630,7 @@ class EnhancedPaletteCard extends StatelessWidget {
   final VoidCallback onDelete;
   final VoidCallback onEdit;
   final VoidCallback onOpenInRoller;
+  final VoidCallback onVisualize;
 
   const EnhancedPaletteCard({
     super.key,
@@ -623,6 +639,7 @@ class EnhancedPaletteCard extends StatelessWidget {
     required this.onDelete,
     required this.onEdit,
     required this.onOpenInRoller,
+    required this.onVisualize,
   });
 
   @override
@@ -692,6 +709,9 @@ class EnhancedPaletteCard extends StatelessWidget {
                               case 'roller':
                                 onOpenInRoller();
                                 break;
+                              case 'visualize':
+                                onVisualize();
+                                break;
                               case 'edit':
                                 onEdit();
                                 break;
@@ -708,6 +728,16 @@ class EnhancedPaletteCard extends StatelessWidget {
                                   Icon(Icons.casino, size: 16),
                                   m.SizedBox(width: 8),
                                   m.Text('Open in Roller'),
+                                ],
+                              ),
+                            ),
+                            const PopupMenuItem(
+                              value: 'visualize',
+                              child: Row(
+                                children: [
+                                  Icon(Icons.auto_fix_high, size: 16),
+                                  m.SizedBox(width: 8),
+                                  m.Text('Visualize'),
                                 ],
                               ),
                             ),

--- a/lib/screens/visualizer_screen.dart
+++ b/lib/screens/visualizer_screen.dart
@@ -9,14 +9,13 @@ import '../services/surface_detection_service.dart';
 import '../services/photo_library_service.dart';
 import '../services/journey/journey_service.dart';
 import '../services/analytics_service.dart';
-import '../firestore/firestore_data_schema.dart';
 import 'photo_library_screen.dart';
 import 'package:color_canvas/widgets/colr_via_icon_button.dart';
 
 enum VisualizerMode { welcome, upload, analyze, selectSurfaces, generate, results, refine }
 
 class VisualizerScreen extends StatefulWidget {
-  final UserPalette? initialPalette;
+  final List<String>? initialPalette;
   final String? storyId;
   const VisualizerScreen({super.key, this.initialPalette, this.storyId});
 
@@ -50,7 +49,7 @@ class _VisualizerScreenState extends State<VisualizerScreen>
 
   // 🎨 COLOR & SURFACE STATE
   final Map<SurfaceType, String> _selectedColors = {};
-  UserPalette? _activePalette;
+  List<String>? _activePalette;
   List<String> _recentColors = [];
 
   // 🔧 PROCESSING STATE
@@ -130,6 +129,12 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   Future<void> _loadInitialData() async {
     _activePalette = widget.initialPalette;
     await _loadRecentColors();
+    if (_activePalette != null && _activePalette!.isNotEmpty) {
+      _recentColors = [
+        ..._activePalette!,
+        ..._recentColors.where((c) => !_activePalette!.contains(c)),
+      ];
+    }
   }
 
   Future<void> _loadRecentColors() async {
@@ -2072,8 +2077,8 @@ class _VisualizerScreenState extends State<VisualizerScreen>
   }
 
   String _getDefaultColor() {
-    if (_activePalette != null && _activePalette!.colors.isNotEmpty) {
-      return _activePalette!.colors.first.hex;
+    if (_activePalette != null && _activePalette!.isNotEmpty) {
+      return _activePalette!.first;
     }
     return _recentColors.isNotEmpty ? _recentColors.first : '#F5F5F5';
   }


### PR DESCRIPTION
## Summary
- allow VisualizerScreen to accept initial palette colors
- add Visualize Palette buttons on color plan and palette detail screens
- support launching Visualizer from library palette cards

## Testing
- `flutter format lib/screens/visualizer_screen.dart lib/screens/color_plan_detail_screen.dart lib/screens/palette_detail_screen.dart lib/screens/projects_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb43d4c1b48322bcd14b2d583bf21a