### PR TITLE
Polish Via assistant overlay styling

### DIFF
--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -116,6 +116,9 @@ class AnalyticsService {
   Future<void> viaActionClicked(String action) =>
       log('via_action_clicked', {'action': action});
 
+  Future<void> viaOpened(String context) =>
+      log('via_open', {'context': context});
+
   Future<void> lightingProfileSelected(String profile) =>
       log('lighting_profile_selected', {'profile': profile});
 


### PR DESCRIPTION
## Summary
- Integrate Via overlay with app theme colors and spacing
- Standardize Via overlay header with ColrViaIconButton and close control
- Add context-aware Via suggestions and analytics hook for overlay opening

## Testing
- `flutter format lib/widgets/via_overlay.dart lib/services/analytics_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb494df06483229d98eadad92cf133