### PR TITLE
Prepare release for v1.0.0

### DIFF
--- a/docs/release_plan.md
+++ b/docs/release_plan.md
@@ -1,0 +1,33 @@
+# Release Plan
+
+## Versioning
+- Bump `pubspec.yaml` to `1.0.0+1`.
+- Android and iOS pull version and build numbers from `pubspec.yaml`.
+
+## Build Commands
+### Android
+```bash
+flutter build appbundle --release
+```
+Produces `build/app/outputs/bundle/release/app-release.aab` for Play Store.
+
+### iOS
+```bash
+flutter build ipa --release
+```
+Generates an Xcode archive and `build/ios/ipa/Runner.ipa` for App Store.
+
+## Staged Rollout
+1. Publish to internal testing tracks.
+2. Roll out to ~10% of users and monitor for 24 hours.
+3. Increase to 100% if no critical issues.
+
+## Monitoring
+- Firebase Crashlytics captures uncaught errors.
+- Review analytics dashboards for unusual drops in engagement or spikes in errors.
+
+## Rollback Strategy
+- **Android:** Halt the staged rollout or unpublish the release in Play Console. Prepare hotfix (e.g., `1.0.1+2`).
+- **iOS:** Remove the version from sale and submit an expedited review for a patched build.
+
+If a critical issue appears, disable affected features remotely (if possible) and ship a hotfix immediately.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,10 @@ Future<void> main() async {
       Debug.info('App', 'main', 'Firebase app already initialized');
     }
 
-    FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      FlutterError.presentError(details);
+      FirebaseCrashlytics.instance.recordFlutterFatalError(details);
+    };
     Debug.info('App', 'main', "Firebase project: '${Firebase.app().options.projectId}'");
 
     isFirebaseInitialized = true;

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -1,5 +1,6 @@
 ﻿import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:color_canvas/widgets/colr_via_icon_button.dart' as app;
 
 class ExploreScreen extends StatefulWidget {
@@ -41,12 +42,13 @@ class _ExploreScreenState extends State<ExploreScreen> {
       appBar: AppBar(
         title: const Text('Explore Color Stories'),
         actions: [
-          app.ColrViaIconButton(
-            icon: Icons.refresh,
-            color: Theme.of(context).colorScheme.onSurface,
-            onPressed: () => setState(() => _isLoading = !_isLoading),
-            semanticLabel: 'Toggle loading',
-          )
+          if (kDebugMode)
+            app.ColrViaIconButton(
+              icon: Icons.refresh,
+              color: Theme.of(context).colorScheme.onSurface,
+              onPressed: () => setState(() => _isLoading = !_isLoading),
+              semanticLabel: 'Toggle loading',
+            )
         ],
       ),
       body: Column(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: color_canvas
 description: "Unleash your inner interior designer with \"Paint Roller,\" the mobile-first app that transforms how you discover and visualize paint palettes, featuring real colors from leading brands like Sherwin-Williams, Benjamin Moore, and Behr."
 publish_to: "none"
-version: 1.0.0
+version: 1.0.0+1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary
- Bump app version to 1.0.0+1
- Hide Explore screen loading toggle outside debug builds
- Ensure Flutter errors are reported to Crashlytics
- Document build, rollout and rollback steps

## Testing
- `flutter test` *(fails: command not found)*
- `flutter build appbundle --release` *(fails: command not found)*
- `flutter build ipa --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4eff1b2c8322b985c8fc8e2899cb