### PR TITLE
Fix widget syntax and const usage

### DIFF
--- a/lib/widgets/paint_column.dart
+++ b/lib/widgets/paint_column.dart
@@ -198,7 +198,8 @@ class _PaintStripeState extends State<PaintStripe> {
                   ],
                 ),
               ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -687,7 +688,8 @@ class _AnimatedPaintStripeState extends State<AnimatedPaintStripe>
                       ),
                     ),
                   ),
-                );
+                ),
+              );
 
                 // Wrap with drag functionality if enabled and preserving long-press
                 if (_RollerEnhancements.enableDragReordering &&

--- a/test/app_flow_test.dart
+++ b/test/app_flow_test.dart
@@ -10,7 +10,7 @@ void main() {
       id: 'p1',
       userId: 'u1',
       name: 'Test Palette',
-      colors: const [
+      colors: [
         PaletteColor(
           paintId: 'c1',
           locked: false,
@@ -30,7 +30,7 @@ void main() {
           hex: '#00FF00',
         ),
       ],
-      tags: const [],
+      tags: [],
       notes: '',
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),


### PR DESCRIPTION
## Summary
- remove invalid const list usages from app flow test
- close nested widget trees correctly in paint column

## Testing
- `dart format lib test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb50e58398832288b80f7b0ee16a59