### PR TITLE
Add interview wizard route and answer clearing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:color_canvas/firebase_config.dart';
 import 'package:color_canvas/theme.dart';
 import 'package:color_canvas/screens/auth_wrapper.dart';
 import 'package:color_canvas/screens/home_screen.dart';
+import 'package:color_canvas/screens/interview_wizard_screen.dart';
 import 'package:color_canvas/screens/login_screen.dart';
 import 'package:color_canvas/screens/color_plan_detail_screen.dart';
 import 'package:color_canvas/screens/visualizer_screen.dart' deferred as viz;
@@ -153,6 +154,7 @@ class MyApp extends StatelessWidget {
             '/interview/voice-setup': (context) => const InterviewVoiceSetupScreen(),
             '/interview/voice': (context) => const InterviewVoiceScreen(),
             '/interview/text': (context) => const InterviewTextScreen(),
+            '/interview/wizard': (context) => const InterviewWizardScreen(),
             '/colorPlan': (context) {
               final args = ModalRoute.of(context)!.settings.arguments
                   as Map<String, dynamic>;

--- a/lib/screens/interview_home_screen.dart
+++ b/lib/screens/interview_home_screen.dart
@@ -77,6 +77,17 @@ class InterviewHomeScreen extends StatelessWidget {
                           ?.copyWith(fontWeight: FontWeight.w600),
                     ),
                   ),
+                  const SizedBox(height: 12),
+                  FilledButton.icon(
+                    icon: const Icon(Icons.edit),
+                    label: const Text("Start Questionnaire"),
+                    onPressed: () {
+                      Navigator.pushNamed(context, '/interview/wizard');
+                    },
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(56),
+                    ),
+                  ),
                   const SizedBox(height: AppDims.gap * 2),
                   OutlinedButton(
                     onPressed: () {

--- a/lib/services/interview_engine.dart
+++ b/lib/services/interview_engine.dart
@@ -130,7 +130,9 @@ class InterviewEngine extends ChangeNotifier {
   }
 
   void setAnswer(String id, dynamic value) {
-    if (value is List && value.isEmpty) {
+    if (value == null) {
+      _answers.remove(id);
+    } else if (value is List && value.isEmpty) {
       _answers.remove(id);
     } else {
       _answers[id] = value;
@@ -146,6 +148,12 @@ class InterviewEngine extends ChangeNotifier {
       }
     }
 
+    notifyListeners();
+  }
+
+  /// Explicitly clear an answer (used by "Prefer not to answer").
+  void clearAnswer(String id) {
+    _answers.remove(id);
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary
- Add questionnaire wizard import and route to main app
- Expose questionnaire start option on interview home screen
- Allow clearing answers and handle nulls in interview engine

## Testing
- `dart format lib/main.dart lib/screens/interview_home_screen.dart lib/services/interview_engine.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4804c7c8322a498174d4e67fcf8