### PR TITLE
feat: add alternates pipeline and single-strip rerolls

### DIFF
--- a/lib/features/roller/paint_repository.dart
+++ b/lib/features/roller/paint_repository.dart
@@ -1,20 +1,49 @@
 import 'package:color_canvas/firestore/firestore_data_schema.dart';
+import 'package:color_canvas/roller_theme/theme_engine.dart';
+import 'package:color_canvas/roller_theme/theme_spec.dart';
 import 'package:color_canvas/data/sample_paints.dart';
 
-/// Responsible for loading & caching Paints from assets and applying coarse filters.
 class PaintRepository {
-  List<Paint>? _cache; // cache all paints in-memory for the session
+  List<Paint>? _allCache; // all paints, session cache
+
+  // LRU-ish caches keyed by normalized keys
+  final Map<String, List<Paint>> _brandCache = {};
+  final Map<String, List<Paint>> _themeCache = {}; // key: themeId|brandKey
 
   Future<List<Paint>> getAll() async {
-    if (_cache != null) return _cache!;
-    final raw = await SamplePaints.getAllPaints(); // returns List<Paint>
-    _cache = raw;
-    return _cache!;
+    if (_allCache != null) return _allCache!;
+    final raw = await SamplePaints.getAllPaints();
+    _allCache = raw;
+    return _allCache!;
   }
 
-  /// Apply brand filter if provided. If brands are empty, returns [paints] unchanged.
   List<Paint> filterByBrands(List<Paint> paints, Set<String> brandIds) {
     if (brandIds.isEmpty) return paints;
     return paints.where((p) => brandIds.contains(p.brandId)).toList();
+  }
+
+  String _brandKey(Set<String> ids) {
+    if (ids.isEmpty) return 'ALL';
+    final sorted = ids.toList()..sort();
+    return sorted.join(',');
+  }
+
+  /// Unified access: apply brand filter and optional theme prefilter with caching.
+  Future<List<Paint>> getPool({
+    required Set<String> brandIds,
+    ThemeSpec? theme,
+  }) async {
+    final all = await getAll();
+
+    // Brand layer
+    final bKey = _brandKey(brandIds);
+    final branded =
+        _brandCache.putIfAbsent(bKey, () => filterByBrands(all, brandIds));
+
+    // Theme layer (optional)
+    if (theme == null) return branded;
+    final tKey = '${theme.id}|$bKey';
+    return _themeCache.putIfAbsent(
+        tKey, () => ThemeEngine.prefilter(branded, theme));
   }
 }

--- a/lib/features/roller/palette_service.dart
+++ b/lib/features/roller/palette_service.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/foundation.dart' show compute;
 import 'package:color_canvas/firestore/firestore_data_schema.dart';
-import 'package:color_canvas/utils/palette_isolate.dart' as isolate;
 import 'package:color_canvas/roller_theme/theme_spec.dart';
+import 'package:color_canvas/utils/palette_isolate.dart' as isolate;
 
-/// A thin facade over the existing isolate entrypoint so all generation funnels through here.
 class PaletteService {
-  /// Generate a full palette.
   Future<List<Paint>> generate({
     required List<Paint> available,
-    required List<Paint?> anchors, // length should match desired strips; null for unlocked
+    required List<Paint?> anchors,
     required bool diversifyBrands,
     List<List<double>>? slotLrvHints,
     List<String>? fixedUndertones,
@@ -16,13 +14,10 @@ class PaletteService {
     double? themeThreshold,
     int attempts = 6,
   }) async {
-    // compute() requires top-level plain-data args; reuse the isolate's map format
     final args = {
       'available': [for (final p in available) (p.toJson()..['id'] = p.id)],
-      'anchors': [
-        for (final p in anchors) (p == null ? null : (p.toJson()..['id'] = p.id))
-      ],
-      'modeIndex': 0, // HarmonyMode is fixed in isolate impl; you can expose later
+      'anchors': [for (final p in anchors) (p == null ? null : (p.toJson()..['id'] = p.id))],
+      'modeIndex': 0,
       'diversify': diversifyBrands,
       'slotLrvHints': slotLrvHints,
       'fixedUndertones': fixedUndertones,
@@ -30,11 +25,34 @@ class PaletteService {
       'themeThreshold': themeThreshold,
       'attempts': attempts,
     };
+    final result = await compute(isolate.rollPipelineInIsolate, args);
+    return [for (final m in result) Paint.fromJson(m, m['id'] as String)];
+  }
 
-    final result = await compute(isolate.rollPaletteInIsolate, args);
-    // Rehydrate Paints
-    return [
-      for (final m in result) Paint.fromJson(m, m['id'] as String),
-    ];
+  /// Collect distinct alternates for one slot (index) given the current anchors.
+  Future<List<Paint>> alternatesForSlot({
+    required List<Paint> available,
+    required List<Paint?> anchors,
+    required int slotIndex,
+    required bool diversifyBrands,
+    List<List<double>>? slotLrvHints,
+    List<String>? fixedUndertones,
+    ThemeSpec? themeSpec,
+    int targetCount = 5,
+    int attemptsPerRound = 3,
+  }) async {
+    final args = {
+      'available': [for (final p in available) (p.toJson()..['id'] = p.id)],
+      'anchors': [for (final p in anchors) (p == null ? null : (p.toJson()..['id'] = p.id))],
+      'slotIndex': slotIndex,
+      'diversify': diversifyBrands,
+      'slotLrvHints': slotLrvHints,
+      'fixedUndertones': fixedUndertones,
+      'themeSpec': themeSpec?.toJson(),
+      'targetCount': targetCount,
+      'attemptsPerRound': attemptsPerRound,
+    };
+    final result = await compute(isolate.alternatesForSlotInIsolate, args);
+    return [for (final m in result) Paint.fromJson(m, m['id'] as String)];
   }
 }

--- a/lib/features/roller/widgets/roller_feed.dart
+++ b/lib/features/roller/widgets/roller_feed.dart
@@ -58,6 +58,9 @@ class _RollerFeedState extends ConsumerState<RollerFeed> {
                     Expanded(
                       child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
+                        onDoubleTap: () => ref
+                            .read(rollerControllerProvider.notifier)
+                            .useNextAlternateForStrip(i),
                         child: Stack(
                           children: [
                             Positioned.fill(

--- a/lib/utils/palette_isolate.dart
+++ b/lib/utils/palette_isolate.dart
@@ -4,6 +4,220 @@ import 'package:color_canvas/roller_theme/theme_engine.dart';
 import 'package:color_canvas/roller_theme/theme_spec.dart';
 import 'package:color_canvas/services/analytics_service.dart';
 
+// ---------- Internal helpers (pure functions) ----------
+List<Paint> _rehydrate(List<Map<String, dynamic>> maps) => [
+  for (final m in maps) Paint.fromJson(m, m['id'] as String),
+];
+
+List<Map<String, dynamic>> _dehydrate(List<Paint> paints) => [
+  for (final p in paints) (p.toJson()..['id'] = p.id),
+];
+
+class _PipelineArgs {
+  _PipelineArgs({
+    required this.available,
+    required this.anchors,
+    required this.modeIndex,
+    required this.diversify,
+    this.slotLrvHints,
+    this.fixedUndertones,
+    this.themeSpec,
+    this.themeThreshold,
+    this.attempts,
+  });
+
+  final List<Map<String, dynamic>> available;
+  final List<Map<String, dynamic>?> anchors;
+  final int modeIndex;
+  final bool diversify;
+  final List<List<double>>? slotLrvHints;
+  final List<String>? fixedUndertones;
+  final Map<String, dynamic>? themeSpec;
+  final double? themeThreshold;
+  final int? attempts;
+
+  Map<String, dynamic> toMap() => {
+    'available': available,
+    'anchors': anchors,
+    'modeIndex': modeIndex,
+    'diversify': diversify,
+    'slotLrvHints': slotLrvHints,
+    'fixedUndertones': fixedUndertones,
+    'themeSpec': themeSpec,
+    'themeThreshold': themeThreshold,
+    'attempts': attempts,
+  };
+
+  static _PipelineArgs from(Map<String, dynamic> m) => _PipelineArgs(
+    available: List<Map<String, dynamic>>.from(m['available'] as List),
+    anchors: List<Map<String, dynamic>?>.from(m['anchors'] as List),
+    modeIndex: m['modeIndex'] as int? ?? 0,
+    diversify: m['diversify'] as bool? ?? true,
+    slotLrvHints: m['slotLrvHints'] == null ? null : List<List<double>>.from((m['slotLrvHints'] as List).map((e) => List<double>.from(e))),
+    fixedUndertones: m['fixedUndertones'] == null ? null : List<String>.from(m['fixedUndertones'] as List),
+    themeSpec: m['themeSpec'] as Map<String, dynamic>?,
+    themeThreshold: (m['themeThreshold'] as num?)?.toDouble(),
+    attempts: m['attempts'] as int?,
+  );
+}
+
+List<Paint> _pipeRollBase({
+  required List<Paint> available,
+  required List<Paint?> anchors,
+  required int modeIndex,
+  required bool diversify,
+  List<List<double>>? slotLrvHints,
+  List<String>? fixedUndertones,
+}) {
+  return PaletteGenerator.rollPalette(
+    availablePaints: available,
+    anchors: anchors,
+    mode: HarmonyMode.values[modeIndex],
+    diversifyBrands: diversify,
+    slotLrvHints: slotLrvHints,
+    fixedUndertones: fixedUndertones,
+  );
+}
+
+List<Paint> _pipeMaybeScoreTheme({
+  required List<Paint> available,
+  required List<Paint?> anchors,
+  required int modeIndex,
+  required bool diversify,
+  required ThemeSpec spec,
+  double threshold = 0.68,
+  List<List<double>>? slotLrvHints,
+  List<String>? fixedUndertones,
+  int attempts = 5,
+}) {
+  // Prefilter to reduce search space
+  final pre = ThemeEngine.prefilter(available, spec);
+  final pool = pre.length < 200 ? available : pre;
+
+  double best = -1.0;
+  List<Paint> bestPalette = const [];
+
+  for (var i = 0; i < attempts; i++) {
+    final rolled = PaletteGenerator.rollPalette(
+      availablePaints: pool,
+      anchors: anchors,
+      mode: HarmonyMode.values[modeIndex],
+      diversifyBrands: diversify,
+      slotLrvHints: slotLrvHints ?? ThemeEngine.slotLrvHintsFor(anchors.length, spec),
+      fixedUndertones: fixedUndertones,
+    );
+    final score = ThemeEngine.scorePalette(rolled, spec);
+    if (score > best) {
+      best = score;
+      bestPalette = rolled;
+    }
+  }
+
+  try {
+    if (best < threshold) {
+      AnalyticsService.instance.logEvent('theme_roll_low_score', {
+        'themeId': spec.id,
+        'score': best,
+        'explain': ThemeEngine.explain(bestPalette, spec),
+      });
+    }
+  } catch (_) {}
+
+  return bestPalette;
+}
+
+// ---------- New public entrypoints ----------
+List<Map<String, dynamic>> rollPipelineInIsolate(Map<String, dynamic> argsMap) {
+  final args = _PipelineArgs.from(argsMap);
+  final available = _rehydrate(args.available);
+  final anchors = [for (final m in args.anchors) (m == null ? null : Paint.fromJson(m, m['id'] as String))];
+
+  if (args.themeSpec == null) {
+    final rolled = _pipeRollBase(
+      available: available,
+      anchors: anchors,
+      modeIndex: args.modeIndex,
+      diversify: args.diversify,
+      slotLrvHints: args.slotLrvHints,
+      fixedUndertones: args.fixedUndertones,
+    );
+    return _dehydrate(rolled);
+  }
+
+  final spec = ThemeSpec.fromJson(args.themeSpec!);
+  final rolled = _pipeMaybeScoreTheme(
+    available: available,
+    anchors: anchors,
+    modeIndex: args.modeIndex,
+    diversify: args.diversify,
+    spec: spec,
+    threshold: args.themeThreshold ?? 0.68,
+    slotLrvHints: args.slotLrvHints ?? ThemeEngine.slotLrvHintsFor(anchors.length, spec),
+    fixedUndertones: args.fixedUndertones,
+    attempts: args.attempts ?? 6,
+  );
+  return _dehydrate(rolled);
+}
+
+/// Produce distinct alternates for a single [slotIndex] while keeping other slots fixed.
+List<Map<String, dynamic>> alternatesForSlotInIsolate(Map<String, dynamic> args) {
+  final available = _rehydrate(List<Map<String, dynamic>>.from(args['available'] as List));
+  final anchors = [
+    for (final m in List<Map<String, dynamic>?>.from(args['anchors'] as List))
+      (m == null ? null : Paint.fromJson(m, m['id'] as String))
+  ];
+  final slotIndex = args['slotIndex'] as int;
+  final diversify = args['diversify'] as bool? ?? true;
+  final fixedUndertones = args['fixedUndertones'] == null ? null : List<String>.from(args['fixedUndertones'] as List);
+  final themeSpecMap = args['themeSpec'] as Map<String, dynamic>?;
+  final targetCount = args['targetCount'] as int? ?? 5;
+  final attemptsPerRound = args['attemptsPerRound'] as int? ?? 3;
+
+  // Lock all other slots; leave only [slotIndex] as null
+  for (var i = 0; i < anchors.length; i++) {
+    if (i != slotIndex) anchors[i] = anchors[i] ?? Paint.fromJson({'hex': '#000000','lab':[0,0,0],'lch':[0,0,0],'rgb':[0,0,0],'brandName':'','brandId':''}, 'LOCK');
+  }
+  anchors[slotIndex] = null; // ensure target slot is unlocked
+
+  final out = <Paint>[];
+  final seenIds = <String>{};
+
+  ThemeSpec? spec;
+  if (themeSpecMap != null) {
+    try { spec = ThemeSpec.fromJson(themeSpecMap); } catch (_) { spec = null; }
+  }
+
+  while (out.length < targetCount) {
+    for (var i = 0; i < attemptsPerRound && out.length < targetCount; i++) {
+      final rolled = (spec == null)
+          ? _pipeRollBase(
+              available: available,
+              anchors: anchors,
+              modeIndex: 0,
+              diversify: diversify,
+              fixedUndertones: fixedUndertones,
+            )
+          : _pipeMaybeScoreTheme(
+              available: available,
+              anchors: anchors,
+              modeIndex: 0,
+              diversify: diversify,
+              spec: spec!,
+              fixedUndertones: fixedUndertones,
+              attempts: 2,
+            );
+      final candidate = rolled[slotIndex];
+      if (!seenIds.contains(candidate.id)) {
+        seenIds.add(candidate.id);
+        out.add(candidate);
+      }
+    }
+    if (out.isEmpty) break; // give up gracefully
+  }
+
+  return _dehydrate(out);
+}
+
 /// Arguments passed to the isolate. All data must be simple/serializable.
 class _RollArgs {
   final List<Map<String, dynamic>> available; // Paint.toJson() + 'id'


### PR DESCRIPTION
## Summary
- cache paint pools by brand and theme for faster reuse
- expose alternatesForSlot generation via isolate pipeline
- support single-strip rerolls and alternates cycling with double tap

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf98d2931c8322a73535fc98afa147