### PR TITLE
Add Explore/Edit mode with editor panel and helper

### DIFF
--- a/lib/features/roller/roller_controller.dart
+++ b/lib/features/roller/roller_controller.dart
@@ -257,6 +257,14 @@ class RollerController extends AsyncNotifier<RollerState> {
     state = AsyncData(s0.copyWith(pages: pages));
   }
 
+  void unlockAll() {
+    final s0 = state.valueOrNull; if (s0 == null || !s0.hasPages) return;
+    final idx = s0.visiblePage;
+    final page = s0.pages[idx];
+    final pages = [...s0.pages]..[idx] = page.copyWith(locks: List<bool>.filled(page.locks.length, false));
+    state = AsyncData(s0.copyWith(pages: pages));
+  }
+
   Future<void> setFilters(RollerFilters filters) async {
     final s0 = state.valueOrNull ?? const RollerState();
     state = AsyncData(s0.copyWith(filters: filters));

--- a/lib/features/roller/roller_ui_mode.dart
+++ b/lib/features/roller/roller_ui_mode.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum RollerMode { explore, edit }
+
+final rollerModeProvider = StateProvider<RollerMode>((ref) => RollerMode.explore);

--- a/lib/features/roller/widgets/editor_panel.dart
+++ b/lib/features/roller/widgets/editor_panel.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:color_canvas/features/roller/roller_controller.dart';
+
+class EditorPanel extends ConsumerWidget {
+  final bool visible;
+  const EditorPanel({super.key, required this.visible});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = ref.watch(rollerControllerProvider).valueOrNull;
+
+    return AnimatedSlide(
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+      offset: visible ? Offset.zero : const Offset(0, 1),
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 200),
+        opacity: visible ? 1 : 0,
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            top: false,
+            child: Material(
+              elevation: 8,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+              color: Theme.of(context).colorScheme.surface,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 200, maxHeight: 380),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        children: [
+                          const Icon(Icons.tune, size: 18),
+                          const SizedBox(width: 8),
+                          Text('Editor', style: Theme.of(context).textTheme.titleMedium),
+                          const Spacer(),
+                          IconButton(
+                            tooltip: 'Filters',
+                            onPressed: () => _openFilters(context, ref),
+                            icon: const Icon(Icons.filter_alt_outlined),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          FilledButton.icon(
+                            onPressed: () => ref.read(rollerControllerProvider.notifier).rerollCurrent(),
+                            icon: const Icon(Icons.casino),
+                            label: const Text('Roll'),
+                          ),
+                          OutlinedButton.icon(
+                            onPressed: () => ref.read(rollerControllerProvider.notifier).rollNext(),
+                            icon: const Icon(Icons.arrow_downward),
+                            label: const Text('Next'),
+                          ),
+                          OutlinedButton.icon(
+                            onPressed: () => ref.read(rollerControllerProvider.notifier).unlockAll(),
+                            icon: const Icon(Icons.lock_open),
+                            label: const Text('Unlock all'),
+                          ),
+                        ],
+                      ),
+                      const Divider(height: 20),
+                      if (s?.currentPage != null)
+                        Expanded(
+                          child: ListView.separated(
+                            itemCount: s!.currentPage!.strips.length,
+                            separatorBuilder: (_, __) => const Divider(height: 12),
+                            itemBuilder: (context, i) {
+                              final isLocked = s.currentPage!.locks[i];
+                              return Row(
+                                children: [
+                                  Text('Strip ${i + 1}'),
+                                  const Spacer(),
+                                  IconButton(
+                                    tooltip: isLocked ? 'Unlock' : 'Lock',
+                                    onPressed: () => ref.read(rollerControllerProvider.notifier).toggleLock(i),
+                                    icon: Icon(isLocked ? Icons.lock : Icons.lock_open),
+                                  ),
+                                  IconButton(
+                                    tooltip: 'Alternate',
+                                    onPressed: () => ref.read(rollerControllerProvider.notifier).useNextAlternateForStrip(i),
+                                    icon: const Icon(Icons.swap_horiz),
+                                  ),
+                                  IconButton(
+                                    tooltip: 'Reroll this strip',
+                                    onPressed: () => ref.read(rollerControllerProvider.notifier).rerollStrip(i),
+                                    icon: const Icon(Icons.autorenew),
+                                  ),
+                                ],
+                              );
+                            },
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openFilters(BuildContext context, WidgetRef ref) {
+    // Reuse the feed's bottom sheet by calling the same method if it is public, or replicate a minimal version.
+    final s = ref.read(rollerControllerProvider).valueOrNull;
+    if (s == null) return;
+    final TextEditingController brandsCtrl = TextEditingController(text: s.filters.brandIds.join(','));
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (_) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Brand IDs (comma-separated)', style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              TextField(controller: brandsCtrl),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () {
+                  final ids = brandsCtrl.text
+                      .split(',')
+                      .map((s) => s.trim())
+                      .where((s) => s.isNotEmpty)
+                      .toSet();
+                  ref.read(rollerControllerProvider.notifier).setFilters(
+                        s.filters.copyWith(brandIds: ids),
+                      );
+                  Navigator.pop(context);
+                },
+                child: const Text('Apply'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/roller/widgets/roller_topbar.dart
+++ b/lib/features/roller/widgets/roller_topbar.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:color_canvas/features/roller/roller_ui_mode.dart';
+
+class RollerTopBar extends ConsumerWidget implements PreferredSizeWidget {
+  const RollerTopBar({super.key});
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight + 8);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(rollerModeProvider);
+
+    return AppBar(
+      title: const Text('Roller'),
+      centerTitle: false,
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: ToggleButtons(
+            isSelected: [mode == RollerMode.explore, mode == RollerMode.edit],
+            onPressed: (i) => ref.read(rollerModeProvider.notifier).state =
+                i == 0 ? RollerMode.explore : RollerMode.edit,
+            borderRadius: BorderRadius.circular(12),
+            constraints: const BoxConstraints(minHeight: 36, minWidth: 72),
+            children: const [
+              Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: Text('Explore')),
+              Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: Text('Edit')),
+            ],
+          ),
+        ),
+        IconButton(
+          tooltip: 'Help',
+          onPressed: () => _showHelp(context),
+          icon: const Icon(Icons.help_outline),
+        ),
+      ],
+    );
+  }
+}
+
+void _showHelp(BuildContext context) {
+  showDialog(
+    context: context,
+    builder: (_) => const _HelpDialog(),
+  );
+}
+
+class _HelpDialog extends StatelessWidget {
+  const _HelpDialog();
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Roller tips'),
+      content: const Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('• Swipe vertically to browse history.'),
+          SizedBox(height: 4),
+          Text('• Tap a strip to lock/unlock it.'),
+          SizedBox(height: 4),
+          Text('• Double‑tap a strip to try another option (or reroll that strip).'),
+          SizedBox(height: 4),
+          Text('• Use Edit mode for quick actions and filters.'),
+        ],
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('Got it')),
+      ],
+    );
+  }
+}

--- a/lib/screens/roller_screen.dart
+++ b/lib/screens/roller_screen.dart
@@ -1,14 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:color_canvas/features/roller/widgets/roller_feed.dart';
+import 'package:color_canvas/features/roller/widgets/roller_topbar.dart';
+import 'package:color_canvas/features/roller/widgets/editor_panel.dart';
+import 'package:color_canvas/features/roller/roller_ui_mode.dart';
 
 class RollerScreen extends ConsumerWidget {
   const RollerScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(
-      body: RollerFeed(),
+    final mode = ref.watch(rollerModeProvider);
+
+    return Scaffold(
+      appBar: const RollerTopBar(),
+      body: Stack(
+        children: [
+          const RollerFeed(),
+          // Slide-up editor when in Edit mode
+          EditorPanel(visible: mode == RollerMode.edit),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- introduce Explore/Edit state provider
- add top bar with mode toggle and help dialog
- include slide-up editor panel with strip controls
- wire RollerScreen to new UI mode and panel
- add unlockAll helper to RollerController

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9beb01088322943c1d9d4f55488f