### PR TITLE
feat: add favorites and hex export

### DIFF
--- a/lib/features/favorites/favorites_repository.dart
+++ b/lib/features/favorites/favorites_repository.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FavoritePalette {
+  final String key; // stable key for a palette (e.g., paintIds joined)
+  final List<String> paintIds;
+  final List<String> hexes;
+  final DateTime createdAt;
+
+  FavoritePalette({
+    required this.key,
+    required this.paintIds,
+    required this.hexes,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+    'key': key,
+    'paintIds': paintIds,
+    'hexes': hexes,
+    'createdAt': createdAt.toIso8601String(),
+  };
+
+  static FavoritePalette fromJson(Map<String, dynamic> m) => FavoritePalette(
+    key: m['key'] as String,
+    paintIds: List<String>.from(m['paintIds'] as List),
+    hexes: List<String>.from(m['hexes'] as List),
+    createdAt: DateTime.tryParse(m['createdAt'] as String? ?? '') ?? DateTime.now(),
+  );
+}
+
+class FavoritesRepository {
+  static const _storeKey = 'roller_favorites_v1';
+
+  Future<List<FavoritePalette>> getAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_storeKey);
+    if (raw == null || raw.isEmpty) return [];
+    final list = List<Map<String, dynamic>>.from(jsonDecode(raw) as List);
+    return [for (final m in list) FavoritePalette.fromJson(m)];
+  }
+
+  Future<void> _saveAll(List<FavoritePalette> items) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = jsonEncode([for (final it in items) it.toJson()]);
+    await prefs.setString(_storeKey, raw);
+  }
+
+  Future<bool> isFavorite(String key) async {
+    final items = await getAll();
+    return items.any((it) => it.key == key);
+  }
+
+  Future<void> toggle(FavoritePalette item) async {
+    final items = await getAll();
+    final idx = items.indexWhere((it) => it.key == item.key);
+    if (idx >= 0) {
+      items.removeAt(idx);
+    } else {
+      items.insert(0, item);
+    }
+    await _saveAll(items);
+  }
+}

--- a/lib/features/roller/widgets/editor_panel.dart
+++ b/lib/features/roller/widgets/editor_panel.dart
@@ -65,6 +65,30 @@ class EditorPanel extends ConsumerWidget {
                             icon: const Icon(Icons.lock_open),
                             label: const Text('Unlock all'),
                           ),
+                          OutlinedButton.icon(
+                            onPressed: () async {
+                              await ref.read(rollerControllerProvider.notifier).toggleFavoriteCurrent();
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text('Toggled favorite for current palette')),
+                                );
+                              }
+                            },
+                            icon: const Icon(Icons.favorite_border),
+                            label: const Text('Favorite'),
+                          ),
+                          OutlinedButton.icon(
+                            onPressed: () async {
+                              await ref.read(rollerControllerProvider.notifier).copyCurrentHexesToClipboard();
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text('HEX copied')),
+                                );
+                              }
+                            },
+                            icon: const Icon(Icons.copy),
+                            label: const Text('Copy HEX'),
+                          ),
                         ],
                       ),
                       const Divider(height: 20),

--- a/lib/features/roller/widgets/roller_topbar.dart
+++ b/lib/features/roller/widgets/roller_topbar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:color_canvas/features/roller/roller_ui_mode.dart';
+import 'package:color_canvas/features/roller/roller_controller.dart';
 
 class RollerTopBar extends ConsumerWidget implements PreferredSizeWidget {
   const RollerTopBar({super.key});
@@ -35,6 +36,43 @@ class RollerTopBar extends ConsumerWidget implements PreferredSizeWidget {
           onPressed: () => _showHelp(context),
           icon: const Icon(Icons.help_outline),
         ),
+        Consumer(builder: (context, ref, _) {
+          final ctrl = ref.read(rollerControllerProvider.notifier);
+          return FutureBuilder<bool>(
+            future: ctrl.isCurrentFavorite(),
+            builder: (context, snap) {
+              final fav = snap.data == true;
+              return IconButton(
+                tooltip: fav ? 'Unfavorite' : 'Favorite',
+                onPressed: () async {
+                  await ctrl.toggleFavoriteCurrent();
+                  // Force rebuild to reflect new state
+                  (context as Element).markNeedsBuild();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(fav ? 'Removed from favorites' : 'Added to favorites')),
+                    );
+                  }
+                },
+                icon: Icon(fav ? Icons.favorite : Icons.favorite_border),
+              );
+            },
+          );
+        }),
+        Consumer(builder: (context, ref, _) {
+          return IconButton(
+            tooltip: 'Copy HEX list',
+            onPressed: () async {
+              await ref.read(rollerControllerProvider.notifier).copyCurrentHexesToClipboard();
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('HEX codes copied')),
+                );
+              }
+            },
+            icon: const Icon(Icons.copy),
+          );
+        }),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- store favorite palettes locally with shared preferences
- expose controller helpers for favorites and clipboard copy
- add favorite and copy actions to top bar and editor panel

## Testing
- ⚠️ `flutter pub add shared_preferences` *(command not found: flutter)*
- ⚠️ `flutter pub get` *(command not found: flutter)*
- ⚠️ `flutter analyze` *(command not found: flutter)*
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bfab179af4832293c5ff870bb23012